### PR TITLE
Enforce user-managed API keys and harden AI endpoints

### DIFF
--- a/.env示範.examples
+++ b/.env示範.examples
@@ -15,22 +15,12 @@ DIRECT_URL="postgresql://postgres:mypassword@localhost:5432/postgres"
 # - 或使用: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 AUTH_SECRET="請填入您的開發環境密鑰，至少32個字元"
 
-# 🤖 AI API 金鑰設定
-# -----------------------------------------------------------------------------
-# 🔴 必須: Google Gemini API 金鑰 (用於聊天功能)
-# 獲取方式: https://makersuite.google.com/app/apikey
-GOOGLE_GEMINI_API_KEY="請填入您的 Google Gemini API 金鑰"
-
-# 🔵 選用: DeepSeek API 金鑰 (可選備用 AI 服務)
-# 獲取方式: https://platform.deepseek.com/
-DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
-
 # =============================================================================
 # 📋 填寫步驟:
 # =============================================================================
 # 1. 複製此檔案: cp .env示範.examples .env.local
 # 2. 編輯 .env.local 檔案
-# 3. 填入您的 API 金鑰
+# 3. 填入必要的資料庫與 AUTH_SECRET 設定
 # 4. 儲存檔案
 # 5. 千萬不要將 .env.local 提交到 Git！
 
@@ -47,4 +37,4 @@ DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
 # DATABASE_URL: 您的生產 PostgreSQL 連線字串
 # DIRECT_URL: 您的生產 PostgreSQL 直接連線字串
 # AUTH_SECRET: 生產環境的認證金鑰
-# GOOGLE_GEMINI_API_KEY: 生產環境的 Gemini API 金鑰
+# Gemini / DeepSeek API 金鑰請改由登入後在應用程式內的設定頁面綁定，避免硬編碼在環境變數。

--- a/DATABASE_WORKFLOW.md
+++ b/DATABASE_WORKFLOW.md
@@ -341,7 +341,6 @@ npm run build:test         # 建置測試
 DATABASE_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 DIRECT_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 AUTH_SECRET="your-dev-secret"
-GOOGLE_GEMINI_API_KEY="your-key"
 ```
 
 ### 故障排除

--- a/README.md
+++ b/README.md
@@ -178,12 +178,11 @@ public/
 - `DATABASE_URL`: PostgreSQL 連接字串
 - `DIRECT_URL`: 直接資料庫連接 (Prisma 用)
 - `AUTH_SECRET`: JWT 認證密鑰
-- `GOOGLE_GEMINI_API_KEY`: Gemini AI API 金鑰
-- `DEEPSEEK_API_KEY`: DeepSeek AI API 金鑰 (可選)
 
 ### 設定方式
 1. **本地開發**: 複製 `.env示範.examples` 為 `.env.local`
 2. **Vercel 部署**: 在 Vercel Dashboard 的 Environment Variables 中設定
+3. **AI 供應商金鑰**: 請於登入後透過系統的「設定 > API 金鑰」頁面綁定並加密儲存，不要在環境變數中填寫。
 
 ## 🚀 部署
 


### PR DESCRIPTION
## Summary
- remove Gemini/DeepSeek environment variables from sample configuration and documentation
- require supplying API keys via request or encrypted user storage for chat and optimizer APIs with stronger payload validation
- clarify setup docs to route AI key management through the in-app settings UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e14eeaaf248332bc4d0ddafbf3e5b2