### PR TITLE
Harden API key handling and document secure setup

### DIFF
--- a/.env示範.examples
+++ b/.env示範.examples
@@ -17,13 +17,8 @@ AUTH_SECRET="請填入您的開發環境密鑰，至少32個字元"
 
 # 🤖 AI API 金鑰設定
 # -----------------------------------------------------------------------------
-# 🔴 必須: Google Gemini API 金鑰 (用於聊天功能)
-# 獲取方式: https://makersuite.google.com/app/apikey
-GOOGLE_GEMINI_API_KEY="請填入您的 Google Gemini API 金鑰"
-
-# 🔵 選用: DeepSeek API 金鑰 (可選備用 AI 服務)
-# 獲取方式: https://platform.deepseek.com/
-DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
+# ❗ 注意：AI 供應商的金鑰將在使用者登入後，於「Settings」畫面中輸入並安全保存。
+#        這裡不再透過環境變數設定任何第三方 API Key，避免意外外洩。
 
 # =============================================================================
 # 📋 填寫步驟:
@@ -47,4 +42,4 @@ DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
 # DATABASE_URL: 您的生產 PostgreSQL 連線字串
 # DIRECT_URL: 您的生產 PostgreSQL 直接連線字串
 # AUTH_SECRET: 生產環境的認證金鑰
-# GOOGLE_GEMINI_API_KEY: 生產環境的 Gemini API 金鑰
+# 其他 AI API Key 請於部署後登入後台，在 Settings 頁面設定

--- a/DATABASE_WORKFLOW.md
+++ b/DATABASE_WORKFLOW.md
@@ -341,8 +341,9 @@ npm run build:test         # 建置測試
 DATABASE_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 DIRECT_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 AUTH_SECRET="your-dev-secret"
-GOOGLE_GEMINI_API_KEY="your-key"
 ```
+
+> 💡 AI 相關的第三方 API Key 需於使用者登入後，在前端 Settings → API Keys 介面輸入，系統會在後端加密保存並與帳號綁定。
 
 ### 故障排除
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,12 +178,14 @@ public/
 - `DATABASE_URL`: PostgreSQL 連接字串
 - `DIRECT_URL`: 直接資料庫連接 (Prisma 用)
 - `AUTH_SECRET`: JWT 認證密鑰
-- `GOOGLE_GEMINI_API_KEY`: Gemini AI API 金鑰
-- `DEEPSEEK_API_KEY`: DeepSeek AI API 金鑰 (可選)
+
+> [!IMPORTANT]
+> 第三方 AI 供應商（例如 Google Gemini、DeepSeek）的 API Key **改由登入後的使用者在前端設定畫面輸入**，並以加密方式儲存在資料庫中。請勿再透過環境變數配置這些敏感金鑰，以降低外洩風險。
 
 ### 設定方式
 1. **本地開發**: 複製 `.env示範.examples` 為 `.env.local`
 2. **Vercel 部署**: 在 Vercel Dashboard 的 Environment Variables 中設定
+3. **AI API Key 綁定**: 使用者登入後，在應用程式的 Settings → API Keys 區段輸入金鑰，即可加密後保存於伺服端。
 
 ## 🚀 部署
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
       ? model.trim()
       : provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat'
 
-    // Resolve API key precedence: body > stored per-user > env
+    // Resolve API key precedence: request payload > stored per-user value
     let effectiveKey = (apiKey || '').trim()
     if (!effectiveKey) {
       const session = await getTokenPayloadFromCookies()

--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -220,7 +220,7 @@ export async function POST(request: NextRequest) {
       systemPrompts?.critic
     )
     
-    // Resolve API key (body > saved per-user)
+    // Resolve API key (request payload > saved per-user value)
     let effectiveKey = (apiKey || '').trim()
     if (!effectiveKey) {
       const session = await getTokenPayloadFromCookies()

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -124,6 +124,7 @@ interface AppState {
   syncStatus: 'idle' | 'syncing' | 'success' | 'error'
   lastSyncAt: number | null
   setSyncStatus: (status: AppState['syncStatus']) => void
+  resetState: () => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -605,6 +606,17 @@ export const useAppStore = create<AppState>()(
 
       // Sync functionality
       setSyncStatus: (syncStatus) => set({ syncStatus }),
+
+      resetState: () => set({
+        tabs: [],
+        activeTab: null,
+        chatStates: {},
+        optimizerStates: {},
+        aipkStates: {},
+        file2fileStates: {},
+        syncStatus: 'idle',
+        lastSyncAt: null,
+      }),
 
       syncToServer: async (forceOverwrite = false) => {
         try {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { initializeSync, resetSync } from '@/lib/syncManager'
 
 interface SyncResult {
   conflict?: boolean
@@ -50,6 +49,7 @@ interface SettingsState extends Settings {
   testConnections: () => Promise<void>
   setConnectionStatus: (provider: 'gemini' | 'deepseek', status: boolean) => void
   resetToDefaults: () => void
+  clearSensitiveData: () => void
   // User model preferences
   addPreferredModel: (provider: 'gemini' | 'deepseek', model: string) => void
   removePreferredModel: (provider: 'gemini' | 'deepseek', model: string) => void
@@ -202,6 +202,17 @@ export const useSettingsStore = create<SettingsState>()(
 
       resetToDefaults: () => set(defaultSettings),
 
+      clearSensitiveData: () => set(() => ({
+        apiKeys: { gemini: '', deepseek: '' },
+        connectionStatus: {
+          gemini: false,
+          deepseek: false,
+          lastTested: 0,
+        },
+        lastSyncAt: null,
+        syncStatus: 'idle',
+      })),
+
       // User model preferences methods
       addPreferredModel: (provider, model) => {
         set((state) => ({
@@ -313,7 +324,6 @@ export const useSettingsStore = create<SettingsState>()(
       name: 'synapse-settings',
       // 排除同步狀態不持久化，只保留設定資料
       partialize: (state) => ({
-        apiKeys: state.apiKeys,
         modelSettings: state.modelSettings,
         systemPrompts: state.systemPrompts,
         features: state.features,


### PR DESCRIPTION
## Summary
- remove third-party AI API key placeholders from environment examples and update docs to route key setup through the app
- stop persisting API keys in client storage, reset local state on logout, and document the intended API key lookup order in server routes
- add a reset helper for the app store to clear user data when accounts sign out

## Testing
- npm run lint *(warnings about existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e152abe6dc833290125709578f2362