### PR TITLE
Refactor settings UI and improve responsive layout

### DIFF
--- a/.env示範.examples
+++ b/.env示範.examples
@@ -17,13 +17,8 @@ AUTH_SECRET="請填入您的開發環境密鑰，至少32個字元"
 
 # 🤖 AI API 金鑰設定
 # -----------------------------------------------------------------------------
-# 🔴 必須: Google Gemini API 金鑰 (用於聊天功能)
-# 獲取方式: https://makersuite.google.com/app/apikey
-GOOGLE_GEMINI_API_KEY="請填入您的 Google Gemini API 金鑰"
-
-# 🔵 選用: DeepSeek API 金鑰 (可選備用 AI 服務)
-# 獲取方式: https://platform.deepseek.com/
-DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
+# ❗ 注意：AI 供應商的金鑰將在使用者登入後，於「Settings」畫面中輸入並安全保存。
+#        這裡不再透過環境變數設定任何第三方 API Key，避免意外外洩。
 
 # =============================================================================
 # 📋 填寫步驟:
@@ -47,4 +42,4 @@ DEEPSEEK_API_KEY="請填入您的 DeepSeek API 金鑰（可選）"
 # DATABASE_URL: 您的生產 PostgreSQL 連線字串
 # DIRECT_URL: 您的生產 PostgreSQL 直接連線字串
 # AUTH_SECRET: 生產環境的認證金鑰
-# GOOGLE_GEMINI_API_KEY: 生產環境的 Gemini API 金鑰
+# 其他 AI API Key 請於部署後登入後台，在 Settings 頁面設定

--- a/DATABASE_WORKFLOW.md
+++ b/DATABASE_WORKFLOW.md
@@ -341,8 +341,9 @@ npm run build:test         # 建置測試
 DATABASE_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 DIRECT_URL="postgresql://user:pass@localhost:5432/chatbot_dev"
 AUTH_SECRET="your-dev-secret"
-GOOGLE_GEMINI_API_KEY="your-key"
 ```
+
+> 💡 AI 相關的第三方 API Key 需於使用者登入後，在前端 Settings → API Keys 介面輸入，系統會在後端加密保存並與帳號綁定。
 
 ### 故障排除
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,12 +178,14 @@ public/
 - `DATABASE_URL`: PostgreSQL 連接字串
 - `DIRECT_URL`: 直接資料庫連接 (Prisma 用)
 - `AUTH_SECRET`: JWT 認證密鑰
-- `GOOGLE_GEMINI_API_KEY`: Gemini AI API 金鑰
-- `DEEPSEEK_API_KEY`: DeepSeek AI API 金鑰 (可選)
+
+> [!IMPORTANT]
+> 第三方 AI 供應商（例如 Google Gemini、DeepSeek）的 API Key **改由登入後的使用者在前端設定畫面輸入**，並以加密方式儲存在資料庫中。請勿再透過環境變數配置這些敏感金鑰，以降低外洩風險。
 
 ### 設定方式
 1. **本地開發**: 複製 `.env示範.examples` 為 `.env.local`
 2. **Vercel 部署**: 在 Vercel Dashboard 的 Environment Variables 中設定
+3. **AI API Key 綁定**: 使用者登入後，在應用程式的 Settings → API Keys 區段輸入金鑰，即可加密後保存於伺服端。
 
 ## 🚀 部署
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -41,10 +41,18 @@ export function middleware(request: NextRequest) {
 
   const response = NextResponse.next()
 
+  if (token && !payload) {
+    response.cookies.delete(AUTH_COOKIE_NAME)
+  }
+
   // 设置安全头
   response.headers.set('X-Frame-Options', 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+
+  if (payload) {
+    response.headers.set('X-User-Authenticated', 'true')
+  }
 
   return response
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
       ? model.trim()
       : provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat'
 
-    // Resolve API key precedence: body > stored per-user > env
+    // Resolve API key precedence: request payload > stored per-user value
     let effectiveKey = (apiKey || '').trim()
     if (!effectiveKey) {
       const session = await getTokenPayloadFromCookies()

--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -220,7 +220,7 @@ export async function POST(request: NextRequest) {
       systemPrompts?.critic
     )
     
-    // Resolve API key (body > saved per-user)
+    // Resolve API key (request payload > saved per-user value)
     let effectiveKey = (apiKey || '').trim()
     if (!effectiveKey) {
       const session = await getTokenPayloadFromCookies()

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/Dialog'
 import { useAuthStore } from '@/store/authStore'
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import dynamic from 'next/dynamic'
+import { useEffect, useMemo, useState } from 'react'
+import { Menu, Settings as SettingsIcon } from 'lucide-react'
 import Sidebar from './Sidebar'
 import { useAppStore } from '@/store/appStore'
 import ChatInterface from '../core/ChatInterface'
@@ -7,51 +10,110 @@ import OptimizerInterface from '../core/OptimizerInterface'
 import AIPKInterface from '../core/AIPKInterface'
 import FileToFileInterface from '../core/FileToFileInterface'
 import HomeView from './HomeView'
-import { useState } from 'react'
 import AvatarButton from '@/components/ui/AvatarButton'
-import SettingsModal from '@/components/settings/SettingsModal'
-import AuthModal from '@/components/auth/AuthModal'
-import { Settings as SettingsIcon } from 'lucide-react'
 import { useAuthStore } from '@/store/authStore'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+
+const SettingsModal = dynamic(() => import('@/components/settings/SettingsModal'), {
+  ssr: false,
+  loading: () => (
+    <div className="p-6 text-sm">Loading settings…</div>
+  ),
+})
+
+const AuthModal = dynamic(() => import('@/components/auth/AuthModal'), {
+  ssr: false,
+})
 
 export default function AppLayout() {
   const { tabs, activeTab } = useAppStore()
   const activeTabData = tabs.find(tab => tab.id === activeTab)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [authOpen, setAuthOpen] = useState(false)
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const { user } = useAuthStore()
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
+
+  useEffect(() => {
+    if (isDesktop) {
+      setIsSidebarOpen(false)
+    }
+  }, [isDesktop])
+
+  const mainContent = useMemo(() => {
+    if (!activeTabData) return <HomeView />
+    switch (activeTabData.type) {
+      case 'chat':
+        return <ChatInterface tabId={activeTabData.id} />
+      case 'optimizer':
+        return <OptimizerInterface tabId={activeTabData.id} />
+      case 'aipk':
+        return <AIPKInterface tabId={activeTabData.id} />
+      case 'file2file':
+        return <FileToFileInterface tabId={activeTabData.id} />
+      default:
+        return <HomeView />
+    }
+  }, [activeTabData])
 
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <main className="flex-1 flex flex-col">
-        {/* Top bar with right-aligned avatar */}
-        <div className="h-12 flex items-center justify-end px-4 gap-2 border-b border-border">
-          <button
-            onClick={() => setSettingsOpen(true)}
-            className="inline-flex items-center justify-center w-8 h-8 rounded-full hover:bg-accent border border-border transition-all duration-200 btn-smooth"
-            title="Settings"
-          >
-            <SettingsIcon className="w-4 h-4" />
-          </button>
-          <AvatarButton
-            onClick={() => setAuthOpen(true)}
-            title={user ? `Logged in as ${user.email}` : "Account"}
-          />
+    <div className="bg-background lg:flex lg:min-h-screen">
+      {isDesktop ? (
+        <Sidebar onOpenSettings={() => setSettingsOpen(true)} />
+      ) : (
+        <>
+          {isSidebarOpen ? (
+            <div className="fixed inset-0 z-40 flex">
+              <button
+                type="button"
+                className="absolute inset-0 bg-black/40"
+                onClick={() => setIsSidebarOpen(false)}
+                aria-label="Close navigation"
+              />
+              <div className="relative z-10 h-full">
+                <Sidebar
+                  onOpenSettings={() => setSettingsOpen(true)}
+                  variant="mobile"
+                  onCloseMobile={() => setIsSidebarOpen(false)}
+                />
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+
+      <main className="flex min-h-screen flex-1 flex-col">
+        <div className="flex h-12 items-center justify-between gap-2 border-b border-border px-4">
+          <div className="flex items-center gap-2">
+            {!isDesktop && (
+              <button
+                type="button"
+                onClick={() => setIsSidebarOpen(true)}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border hover:bg-accent"
+                aria-label="Open navigation"
+              >
+                <Menu className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              onClick={() => setSettingsOpen(true)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border transition-all duration-200 hover:bg-accent"
+              title="Settings"
+              aria-label="Open settings"
+            >
+              <SettingsIcon className="h-4 w-4" />
+            </button>
+            <AvatarButton
+              onClick={() => setAuthOpen(true)}
+              title={user ? `Logged in as ${user.email}` : 'Account'}
+            />
+          </div>
         </div>
-        {!activeTabData ? (
-          <HomeView />
-        ) : activeTabData.type === 'chat' ? (
-          <ChatInterface tabId={activeTabData.id} />
-        ) : activeTabData.type === 'optimizer' ? (
-          <OptimizerInterface tabId={activeTabData.id} />
-        ) : activeTabData.type === 'aipk' ? (
-          <AIPKInterface tabId={activeTabData.id} />
-        ) : activeTabData.type === 'file2file' ? (
-          <FileToFileInterface tabId={activeTabData.id} />
-        ) : (
-          <HomeView />
-        )}
+
+        <div className="flex-1 overflow-y-auto">{mainContent}</div>
+
         <SettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
         <AuthModal open={authOpen} onOpenChange={setAuthOpen} />
       </main>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,17 +1,21 @@
 'use client'
 
 import { useState } from 'react'
-import { MessageSquare, Settings, Sparkles, Plus, ChevronLeft } from 'lucide-react'
+import { MessageSquare, Settings, Sparkles, Plus, ChevronLeft, X } from 'lucide-react'
 import { useAppStore } from '@/store/appStore'
 import { cn } from '@/lib/utils'
-import SettingsModal from '../settings/SettingsModal'
 import Image from 'next/image'
 import AIPKIcon from '../ui/AIPKIcon'
 import FileToFileIcon from '../ui/FileToFileIcon'
 
-export default function Sidebar() {
+interface SidebarProps {
+  onOpenSettings: () => void
+  variant?: 'desktop' | 'mobile'
+  onCloseMobile?: () => void
+}
+
+export default function Sidebar({ onOpenSettings, variant = 'desktop', onCloseMobile }: SidebarProps) {
   const { tabs, activeTab, setActiveTab, closeTab, createChatTab, createOptimizerTab, createAIPKTab, createFile2FileTab } = useAppStore()
-  const [settingsOpen, setSettingsOpen] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)
 
   const handleNewChat = () => {
@@ -34,7 +38,27 @@ export default function Sidebar() {
     setIsCollapsed(!isCollapsed)
   }
 
-  if (isCollapsed) {
+  const handleSettingsClick = () => {
+    onOpenSettings()
+    if (variant === 'mobile' && onCloseMobile) {
+      onCloseMobile()
+    }
+  }
+
+  const handleTabSelection = (tabId: string) => {
+    setActiveTab(tabId)
+    if (variant === 'mobile' && onCloseMobile) {
+      onCloseMobile()
+    }
+  }
+
+  const maybeCloseMobile = () => {
+    if (variant === 'mobile' && onCloseMobile) {
+      onCloseMobile()
+    }
+  }
+
+  if (isCollapsed && variant === 'desktop') {
     return (
       <div className="w-16 bg-sidebar border-r border-border h-full flex flex-col">
         {/* Collapsed Header */}
@@ -43,6 +67,7 @@ export default function Sidebar() {
             onClick={toggleSidebar}
             className="w-full flex justify-center p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
             title="Expand Sidebar"
+            aria-label="Expand sidebar"
           >
             <Image
               src="/logo_optimized.png"
@@ -60,6 +85,7 @@ export default function Sidebar() {
             onClick={handleNewChat}
             className="w-full flex justify-center p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
             title="New Chat"
+            aria-label="Start new chat"
           >
             <Plus className="w-5 h-5" />
           </button>
@@ -67,6 +93,7 @@ export default function Sidebar() {
             onClick={handleNewOptimizer}
             className="w-full flex justify-center p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
             title="New Optimizer"
+            aria-label="Open prompt optimizer"
           >
             <Sparkles className="w-5 h-5" />
           </button>
@@ -74,6 +101,7 @@ export default function Sidebar() {
             onClick={handleNewAIPK}
             className="w-full flex justify-center p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
             title="New AI PK"
+            aria-label="Create AI PK session"
           >
             <AIPKIcon className="w-5 h-5" />
           </button>
@@ -81,6 +109,7 @@ export default function Sidebar() {
             onClick={handleNewFile2File}
             className="w-full flex justify-center p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
             title="New File to File"
+            aria-label="Start file to file conversion"
           >
             <FileToFileIcon className="w-5 h-5" />
           </button>
@@ -90,7 +119,10 @@ export default function Sidebar() {
   }
 
   return (
-    <div className="w-64 bg-sidebar border-r border-border h-full flex flex-col">
+    <div className={cn(
+      'bg-sidebar border-border h-full flex flex-col',
+      variant === 'mobile' ? 'w-64 border-r shadow-lg' : 'w-64 border-r'
+    )}>
       {/* Header */}
       <div className="p-4 border-b border-border">
         <div className="flex items-center justify-between">
@@ -101,13 +133,28 @@ export default function Sidebar() {
             height={32}
             className="rounded"
           />
-          <button
-            onClick={toggleSidebar}
-            className="p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
-            title="Collapse Sidebar"
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
+          <div className="flex items-center gap-2">
+            {variant === 'mobile' ? (
+              <button
+                onClick={() => {
+                  maybeCloseMobile()
+                }}
+                className="p-2 hover:bg-accent rounded-md transition-colors"
+                aria-label="Close menu"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            ) : (
+              <button
+                onClick={toggleSidebar}
+                className="p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
+                title="Collapse Sidebar"
+                aria-label="Collapse sidebar"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+            )}
+          </div>
         </div>
       </div>
 
@@ -117,6 +164,7 @@ export default function Sidebar() {
           onClick={handleNewChat}
           className="flex items-center gap-3 w-full p-3 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
           title="New Chat"
+          aria-label="Start new chat"
         >
           <Plus className="w-4 h-4 flex-shrink-0" />
           <span className="text-sm">新聊天</span>
@@ -125,6 +173,7 @@ export default function Sidebar() {
           onClick={handleNewOptimizer}
           className="flex items-center gap-3 w-full p-3 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
           title="New Optimizer"
+          aria-label="Open prompt optimizer"
         >
           <Sparkles className="w-4 h-4 flex-shrink-0" />
           <span className="text-sm">Prompt Optimizer</span>
@@ -133,6 +182,7 @@ export default function Sidebar() {
           onClick={handleNewAIPK}
           className="flex items-center gap-3 w-full p-3 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
           title="New AI PK"
+          aria-label="Create AI PK session"
         >
           <AIPKIcon className="w-4 h-4 flex-shrink-0" />
           <span className="text-sm">AI PK</span>
@@ -141,6 +191,7 @@ export default function Sidebar() {
           onClick={handleNewFile2File}
           className="flex items-center gap-3 w-full p-3 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
           title="New File to File"
+          aria-label="Start file to file conversion"
         >
           <FileToFileIcon className="w-4 h-4 flex-shrink-0" />
           <span className="text-sm">File to File</span>
@@ -162,7 +213,7 @@ export default function Sidebar() {
                   ? 'bg-primary text-primary-foreground'
                   : 'hover:bg-accent'
               )}
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => handleTabSelection(tab.id)}
             >
               {tab.type === 'chat' ? (
                 <MessageSquare className="w-4 h-4 flex-shrink-0" />
@@ -180,8 +231,12 @@ export default function Sidebar() {
                 onClick={(e) => {
                   e.stopPropagation()
                   closeTab(tab.id)
+                  if (variant === 'mobile' && onCloseMobile) {
+                    onCloseMobile()
+                  }
                 }}
                 className="opacity-0 group-hover:opacity-100 p-1 hover:bg-destructive rounded transition-all duration-200 btn-smooth"
+                aria-label={`Close ${tab.title}`}
               >
                 <Plus className="w-3 h-3 rotate-45" />
               </button>
@@ -193,17 +248,13 @@ export default function Sidebar() {
       {/* Footer */}
       <div className="p-4 border-t border-border">
         <button
-          onClick={() => setSettingsOpen(true)}
+          onClick={handleSettingsClick}
           className="flex items-center gap-3 w-full p-2 hover:bg-accent rounded-md transition-all duration-200 btn-smooth"
+          aria-label="Open settings"
         >
           <Settings className="w-4 h-4" />
           <span className="text-sm">Settings</span>
         </button>
-        
-        <SettingsModal 
-          open={settingsOpen} 
-          onOpenChange={setSettingsOpen} 
-        />
       </div>
     </div>
   )

--- a/src/components/settings/APIKeySection.tsx
+++ b/src/components/settings/APIKeySection.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { TestTube } from 'lucide-react'
+import { CollapsibleSection } from './CollapsibleSection'
+import type { Settings } from '@/store/settingsStore'
+import type { ProviderName } from '@/lib/providers'
+import { cn } from '@/lib/utils'
+
+interface APIKeySectionProps {
+  apiKeys: Settings['apiKeys']
+  connectionStatus: Settings['connectionStatus']
+  onChangeKey: (provider: keyof Settings['apiKeys'], value: string) => void
+  onTestConnection: (provider: ProviderName) => Promise<void>
+  isTesting: ProviderName | null
+}
+
+const providerConfig: Record<ProviderName, { label: string; placeholder: string; helper?: string }> = {
+  gemini: {
+    label: 'Gemini AI Studio API Key',
+    placeholder: 'Enter your Gemini AI Studio API key',
+  },
+  deepseek: {
+    label: 'DeepSeek API Key',
+    placeholder: 'Enter your DeepSeek API key',
+  },
+}
+
+export function APIKeySection({ apiKeys, connectionStatus, onChangeKey, onTestConnection, isTesting }: APIKeySectionProps) {
+  return (
+    <CollapsibleSection
+      title="API Keys"
+      icon={
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H7l5-4-5-4h4l2.257-2.257A6 6 0 0119 9z" />
+        </svg>
+      }
+      defaultExpanded
+    >
+      <div className="space-y-4">
+        {(Object.keys(providerConfig) as ProviderName[]).map((provider) => {
+          const meta = providerConfig[provider]
+          const value = apiKeys[provider]
+          const isCurrentlyTesting = isTesting === provider
+          const statusClass = connectionStatus[provider] ? 'bg-green-500' : 'bg-red-500'
+
+          return (
+            <div key={provider} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="block text-sm font-medium" htmlFor={`${provider}-api-key`}>
+                  {meta.label}
+                </label>
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className={cn('inline-block h-2.5 w-2.5 rounded-full', statusClass)} aria-hidden />
+                  {connectionStatus[provider] ? 'Connected' : 'Not connected'}
+                </span>
+              </div>
+              <div className="flex gap-2">
+                <input
+                  id={`${provider}-api-key`}
+                  type="password"
+                  value={value}
+                  onChange={(event) => onChangeKey(provider, event.target.value)}
+                  placeholder={meta.placeholder}
+                  className="flex-1 rounded-lg border border-border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+                  autoComplete="off"
+                />
+                <button
+                  type="button"
+                  onClick={() => onTestConnection(provider)}
+                  disabled={!value || isCurrentlyTesting}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-lg border border-border px-3 py-2 transition-colors',
+                    value && !isCurrentlyTesting ? 'hover:bg-accent' : 'cursor-not-allowed opacity-50'
+                  )}
+                  aria-live="polite"
+                >
+                  <TestTube className={cn('h-4 w-4', isCurrentlyTesting && 'animate-spin')} aria-hidden />
+                  <span className="sr-only">Test {provider} connection</span>
+                </button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </CollapsibleSection>
+  )
+}
+

--- a/src/components/settings/CollapsibleSection.tsx
+++ b/src/components/settings/CollapsibleSection.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface CollapsibleSectionProps {
+  title: string
+  icon: ReactNode
+  defaultExpanded?: boolean
+  children: ReactNode
+}
+
+export function CollapsibleSection({ title, icon, defaultExpanded = false, children }: CollapsibleSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="w-full flex items-center justify-between p-4 bg-muted/50 hover:bg-muted transition-colors"
+        aria-expanded={isExpanded}
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 text-primary" aria-hidden>
+            {icon}
+          </div>
+          <h4 className="text-sm font-semibold text-left">{title}</h4>
+        </div>
+        <div className="flex-shrink-0 transition-transform duration-200">
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-muted-foreground" aria-hidden />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-muted-foreground" aria-hidden />
+          )}
+        </div>
+      </button>
+
+      <div
+        className={cn(
+          'overflow-hidden transition-all duration-300 ease-in-out',
+          isExpanded ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0'
+        )}
+      >
+        <div className="p-4 bg-background">{children}</div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/settings/FeatureToggleSection.tsx
+++ b/src/components/settings/FeatureToggleSection.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { CollapsibleSection } from './CollapsibleSection'
+import type { Settings } from '@/store/settingsStore'
+
+interface FeatureToggleSectionProps {
+  features: Settings['features']
+  setFeature: (feature: keyof Settings['features'], enabled: boolean) => void
+}
+
+export function FeatureToggleSection({ features, setFeature }: FeatureToggleSectionProps) {
+  const toggles: { key: keyof Settings['features']; title: string; description: string }[] = [
+    {
+      key: 'showTokenUsage',
+      title: 'Show Token Usage',
+      description: 'Display token counts in chat interface',
+    },
+    {
+      key: 'enableGeminiCache',
+      title: 'Enable Gemini Cache',
+      description: 'Use caching to reduce API costs (Gemini only)',
+    },
+  ]
+
+  return (
+    <CollapsibleSection
+      title="Features"
+      icon={<svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6l4 2" /></svg>}
+      defaultExpanded
+    >
+      <div className="space-y-4">
+        {toggles.map(({ key, title, description }) => (
+          <div key={key} className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">{title}</p>
+              <p className="text-xs text-muted-foreground">{description}</p>
+            </div>
+            <label className="relative inline-flex items-center">
+              <input
+                type="checkbox"
+                checked={features[key]}
+                onChange={(event) => setFeature(key, event.target.checked)}
+                className="peer sr-only"
+              />
+              <span className="pointer-events-none h-6 w-11 rounded-full bg-gray-200 transition peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/25 peer-checked:bg-primary" />
+              <span className="pointer-events-none absolute left-[2px] top-[2px] h-5 w-5 rounded-full border border-gray-300 bg-white transition peer-checked:translate-x-full peer-checked:border-white" />
+              <span className="sr-only">Toggle {title}</span>
+            </label>
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  )
+}
+

--- a/src/components/settings/FeedbackBanner.tsx
+++ b/src/components/settings/FeedbackBanner.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { SettingsFeedback } from '@/hooks/useSettingsModal'
+import { cn } from '@/lib/utils'
+
+interface FeedbackBannerProps {
+  feedback: SettingsFeedback
+  onDismiss: () => void
+}
+
+const variantStyles: Record<SettingsFeedback['type'], string> = {
+  success: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800',
+  warning: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-200 dark:border-amber-800',
+  error: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800',
+}
+
+export function FeedbackBanner({ feedback, onDismiss }: FeedbackBannerProps) {
+  return (
+    <div
+      role={feedback.type === 'error' ? 'alert' : 'status'}
+      className={cn(
+        'flex items-start gap-3 rounded-lg border p-3 text-sm shadow-sm',
+        variantStyles[feedback.type]
+      )}
+    >
+      <div className="flex-1">
+        <p className="font-medium">{feedback.title}</p>
+        {feedback.description && <p className="mt-1 leading-relaxed">{feedback.description}</p>}
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="rounded-full p-1 hover:bg-black/5 dark:hover:bg-white/5"
+        aria-label="Dismiss message"
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  )
+}
+

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -75,7 +75,14 @@ export function ModelSettingsSection({
               <label className="block text-sm font-medium" htmlFor="default-model">
                 Default Model
               </label>
-              <Info className="h-4 w-4 text-muted-foreground" aria-hidden title="Select your preferred models below. Removed models won't appear in dropdown menus." />
+              <span
+                className="relative flex h-4 w-4 items-center justify-center text-muted-foreground"
+                role="img"
+                aria-label="Select your preferred models below. Removed models won't appear in dropdown menus."
+                title="Select your preferred models below. Removed models won't appear in dropdown menus."
+              >
+                <Info className="h-4 w-4" aria-hidden />
+              </span>
             </div>
             <button
               type="button"

--- a/src/components/settings/ModelSettingsSection.tsx
+++ b/src/components/settings/ModelSettingsSection.tsx
@@ -1,0 +1,175 @@
+'use client'
+
+import { Info, RefreshCw, X } from 'lucide-react'
+import { CollapsibleSection } from './CollapsibleSection'
+import type { Settings } from '@/store/settingsStore'
+import type { ProviderName } from '@/lib/providers'
+import { cn } from '@/lib/utils'
+
+interface ModelSettingsSectionProps {
+  modelSettings: Settings['modelSettings']
+  setModelSettings: (settings: Partial<Settings['modelSettings']>) => void
+  availableModels: string[]
+  dynamicModels: Record<ProviderName, string[]>
+  userModelPreferences: Settings['userModelPreferences']
+  addPreferredModel: (provider: ProviderName, model: string) => void
+  removePreferredModel: (provider: ProviderName, model: string) => void
+  refreshModels: () => Promise<Record<ProviderName, string[]>>
+  isRefreshing: boolean
+}
+
+export function ModelSettingsSection({
+  modelSettings,
+  setModelSettings,
+  availableModels,
+  dynamicModels,
+  userModelPreferences,
+  addPreferredModel,
+  removePreferredModel,
+  refreshModels,
+  isRefreshing,
+}: ModelSettingsSectionProps) {
+  const provider = modelSettings.defaultProvider
+  const providerModels = dynamicModels[provider] || []
+
+  const togglePreferred = (model: string) => {
+    const isPreferred = userModelPreferences[provider]?.includes(model)
+    if (isPreferred) {
+      removePreferredModel(provider, model)
+    } else {
+      addPreferredModel(provider, model)
+    }
+  }
+
+  return (
+    <CollapsibleSection
+      title="Model Settings"
+      icon={
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      }
+      defaultExpanded
+    >
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-2" htmlFor="default-provider">
+            Default Provider
+          </label>
+          <select
+            id="default-provider"
+            value={modelSettings.defaultProvider}
+            onChange={(event) =>
+              setModelSettings({ defaultProvider: event.target.value as ProviderName })
+            }
+            className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          >
+            <option value="gemini">Gemini</option>
+            <option value="deepseek">DeepSeek</option>
+          </select>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <label className="block text-sm font-medium" htmlFor="default-model">
+                Default Model
+              </label>
+              <Info className="h-4 w-4 text-muted-foreground" aria-hidden title="Select your preferred models below. Removed models won't appear in dropdown menus." />
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                refreshModels().catch((error) => {
+                  console.warn('Manual model refresh failed:', error)
+                })
+              }}
+              disabled={isRefreshing}
+              className={cn(
+                'rounded-md p-1 transition-colors',
+                isRefreshing ? 'cursor-not-allowed opacity-50' : 'hover:bg-accent text-muted-foreground hover:text-foreground'
+              )}
+              title="Refresh available models"
+            >
+              <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} aria-hidden />
+              <span className="sr-only">Refresh provider models</span>
+            </button>
+          </div>
+          <div className="mb-3">
+            <label className="mb-1 block text-xs text-muted-foreground" htmlFor="default-model">
+              Current Default Model
+            </label>
+            <select
+              id="default-model"
+              value={modelSettings.defaultModel}
+              onChange={(event) => setModelSettings({ defaultModel: event.target.value })}
+              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              {availableModels.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-2 block text-xs text-muted-foreground">
+              Manage Available Models (click × to toggle availability)
+            </label>
+            <div className="max-h-32 overflow-y-auto rounded-lg border border-border p-2 space-y-1">
+              {providerModels.map((model) => {
+                const isPreferred = userModelPreferences[provider]?.includes(model)
+                return (
+                  <div
+                    key={model}
+                    className="flex items-center justify-between rounded px-2 py-1 text-sm hover:bg-accent/50"
+                  >
+                    <span
+                      className={cn('flex-1 truncate', isPreferred ? 'text-foreground' : 'text-muted-foreground')}
+                    >
+                      {model}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => togglePreferred(model)}
+                      className={cn(
+                        'ml-2 rounded p-1 transition-colors',
+                        isPreferred
+                          ? 'text-muted-foreground hover:bg-destructive hover:text-destructive-foreground'
+                          : 'text-muted-foreground hover:bg-primary hover:text-primary-foreground'
+                      )}
+                      title={isPreferred ? 'Remove from available models' : 'Add to available models'}
+                    >
+                      <X className="h-3 w-3" aria-hidden />
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Only preferred models will appear in dropdown menus throughout the app.
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-2" htmlFor="temperature">
+            Temperature: {modelSettings.temperature.toFixed(2)}
+          </label>
+          <input
+            id="temperature"
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={modelSettings.temperature}
+            onChange={(event) => setModelSettings({ temperature: Number(event.target.value) })}
+            className="w-full"
+          />
+        </div>
+      </div>
+    </CollapsibleSection>
+  )
+}
+

--- a/src/components/settings/SettingsFooter.tsx
+++ b/src/components/settings/SettingsFooter.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Cloud, Save } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface SettingsFooterProps {
+  onClose: () => void
+  onSave: () => void
+  onManualSync: () => void
+  isSyncing: boolean
+}
+
+export function SettingsFooter({ onClose, onSave, onManualSync, isSyncing }: SettingsFooterProps) {
+  return (
+    <div className="flex items-center justify-between border-t border-border pt-4">
+      <button
+        type="button"
+        onClick={onManualSync}
+        disabled={isSyncing}
+        className={cn(
+          'flex items-center gap-2 rounded-lg border border-border px-4 py-2 transition-colors',
+          isSyncing ? 'cursor-not-allowed opacity-50' : 'hover:bg-accent'
+        )}
+      >
+        <Cloud className={cn('h-4 w-4', isSyncing && 'animate-spin')} aria-hidden />
+        {isSyncing ? 'Syncing…' : 'Sync Data'}
+      </button>
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg border border-border px-4 py-2 transition-colors hover:bg-accent"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          <Save className="h-4 w-4" aria-hidden />
+          Save Settings
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,61 +1,18 @@
 'use client'
 
-import { useEffect, useMemo, useState, useCallback } from 'react'
-import { Save, TestTube, RefreshCw, ChevronDown, ChevronRight, X, Info, Cloud } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/Dialog'
-import { useSettingsStore } from '@/store/settingsStore'
-import { cn } from '@/lib/utils'
-import { getModelOptions, refreshDynamicModels, type ProviderName } from '@/lib/providers'
-import { manualSync } from '@/lib/syncManager'
+import { APIKeySection } from './APIKeySection'
+import { ModelSettingsSection } from './ModelSettingsSection'
+import { SystemPromptSection } from './SystemPromptSection'
+import { FeatureToggleSection } from './FeatureToggleSection'
+import { SettingsFooter } from './SettingsFooter'
+import { FeedbackBanner } from './FeedbackBanner'
+import { SettingsStatusHeader } from './SettingsStatusHeader'
+import { useSettingsModal } from '@/hooks/useSettingsModal'
 
 interface SettingsModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-interface CollapsibleSectionProps {
-  title: string
-  icon: React.ReactNode
-  defaultExpanded?: boolean
-  children: React.ReactNode
-}
-
-function CollapsibleSection({ title, icon, defaultExpanded = false, children }: CollapsibleSectionProps) {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
-
-  return (
-    <div className="border border-border rounded-lg overflow-hidden">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-4 bg-muted/50 hover:bg-muted transition-colors"
-      >
-        <div className="flex items-center gap-3">
-          <div className="flex-shrink-0 text-primary">
-            {icon}
-          </div>
-          <h4 className="text-sm font-semibold text-left">{title}</h4>
-        </div>
-        <div className="flex-shrink-0 transition-transform duration-200">
-          {isExpanded ? (
-            <ChevronDown className="w-4 h-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="w-4 h-4 text-muted-foreground" />
-          )}
-        </div>
-      </button>
-
-      <div
-        className={cn(
-          "overflow-hidden transition-all duration-300 ease-in-out",
-          isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
-        )}
-      >
-        <div className="p-4 bg-background">
-          {children}
-        </div>
-      </div>
-    </div>
-  )
 }
 
 export default function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
@@ -70,654 +27,71 @@ export default function SettingsModal({ open, onOpenChange }: SettingsModalProps
     setModelSettings,
     setSystemPrompt,
     setFeature,
-    testConnections,
     addPreferredModel,
     removePreferredModel,
-    setConnectionStatus,
-  } = useSettingsStore()
-
-  const [isTesting, setIsTesting] = useState(false)
-  const [dynamicModels, setDynamicModels] = useState<Record<ProviderName, string[]>>(getModelOptions())
-  const [isRefreshingModels, setIsRefreshingModels] = useState(false)
-  const [isSyncing, setIsSyncing] = useState(false)
-
-  // Selector function to filter models based on user preferences
-  const getFilteredModels = useCallback((provider: ProviderName, availableModels: string[]) => {
-    const preferredModels = userModelPreferences[provider] || []
-
-    // If no preferences set, return all available models
-    if (preferredModels.length === 0) {
-      return availableModels
-    }
-
-    // Return intersection of available models and user preferences
-    return availableModels.filter(model => preferredModels.includes(model))
-  }, [userModelPreferences])
-
-  // Compute model list bound to provider with user preferences
-  const availableModels = useMemo(() => {
-    const allModels = dynamicModels[modelSettings.defaultProvider] || []
-    return getFilteredModels(modelSettings.defaultProvider, allModels)
-  }, [dynamicModels, modelSettings.defaultProvider, getFilteredModels])
-
-  // Initialize user preferences with all available models if not set
-  useEffect(() => {
-    if (open && dynamicModels[modelSettings.defaultProvider]) {
-      const provider = modelSettings.defaultProvider
-      const allModels = dynamicModels[provider] || []
-      const currentPreferences = userModelPreferences[provider]
-
-      // If no preferences are set, initialize with all available models
-      if (currentPreferences.length === 0 && allModels.length > 0) {
-        allModels.forEach(model => addPreferredModel(provider, model))
-      }
-    }
-  }, [open, dynamicModels, modelSettings.defaultProvider, userModelPreferences, addPreferredModel])
-
-  // Ensure defaultModel belongs to current provider
-  useEffect(() => {
-    if (!availableModels.includes(modelSettings.defaultModel)) {
-      setModelSettings({ defaultModel: availableModels[0] })
-    }
-  }, [availableModels, modelSettings.defaultModel, setModelSettings])
-
-  // Refresh dynamic models when modal opens
-  useEffect(() => {
-    if (!open) return
-
-    const refreshModels = async () => {
-      setIsRefreshingModels(true)
-      try {
-        const updatedModels = await refreshDynamicModels({
-          gemini: apiKeys.gemini,
-          deepseek: apiKeys.deepseek,
-        })
-        setDynamicModels(updatedModels)
-      } catch (error) {
-        console.warn('Failed to refresh models in settings modal:', error)
-        // Keep existing models if refresh fails
-      } finally {
-        setIsRefreshingModels(false)
-      }
-    }
-
-    refreshModels()
-    // Also test connections when modal opens
-    if (open) {
-      console.log('Testing connections on modal open...')
-      testConnections().then(() => {
-        console.log('Connection test completed')
-      }).catch((error) => {
-        console.error('Connection test failed:', error)
-      })
-    }
-  }, [open, apiKeys.gemini, apiKeys.deepseek, testConnections])
-
+    availableModels,
+    dynamicModels,
+    isRefreshingModels,
+    isTestingConnection,
+    isSyncing,
+    feedback,
+    dismissFeedback,
+    refreshModels,
+    testProviderConnection,
+    handleManualSync,
+  } = useSettingsModal(open)
 
   const handleSave = () => {
-    // Settings are automatically saved to the store
     onOpenChange(false)
-  }
-
-  const handleManualSync = async () => {
-    setIsSyncing(true)
-    try {
-      const result = await manualSync()
-      if (result.settingsConflict || result.appStateConflict) {
-        alert('⚠️ 同步完成，但存在衝突。請檢查資料是否正確。')
-      } else {
-        alert('✅ 資料同步完成！')
-      }
-    } catch (error) {
-      console.error('Manual sync failed:', error)
-      alert('❌ 同步失敗，請檢查網路連線或重新登入。')
-    } finally {
-      setIsSyncing(false)
-    }
-  }
-
-  const handleTestConnection = async (provider: string) => {
-    console.log(`Testing connection for ${provider}...`)
-    setIsTesting(true)
-    const providerKey = provider as 'gemini' | 'deepseek'
-    try {
-      const apiKey = apiKeys[provider as keyof typeof apiKeys]
-
-      const response = await fetch('/api/test', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ provider, apiKey }),
-      })
-      
-      const result = await response.json()
-
-      if (result.success) {
-        alert(`✅ ${provider.toUpperCase()} API connection successful!\n${result.message}`)
-        setConnectionStatus(providerKey, true)
-        // Save to server after success
-        const saveRes = await fetch('/api/keys', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ provider, apiKey })
-        })
-        if (saveRes.ok) {
-          // Connection saved successfully, testConnections will update the status
-          await testConnections()
-        } else if (saveRes.status === 401) {
-          // Not logged in: keep green because key tested OK locally
-          alert(`✅ ${provider.toUpperCase()} API key saved locally`)
-        }
-      } else {
-        alert(`❌ ${provider.toUpperCase()} API connection failed:\n${result.message}`)
-        setConnectionStatus(providerKey, false)
-      }
-    } catch (error) {
-      console.error('Connection test failed:', error)
-      alert(`❌ ${provider.toUpperCase()} API connection test failed: Network error`)
-      setConnectionStatus(providerKey, false)
-    } finally {
-      setIsTesting(false)
-    }
-  }
-
-  const restoreDefaultPrompt = (promptType: 'improver' | 'critic' | 'chat') => {
-    const defaultPrompts = {
-      improver: `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
-
-你的工作流程是：
-1.  **分析輸入**: 仔細理解用戶的\`初始需求\`、\`當前 Prompt 版本\`以及\`審核者回饋\`。
-2.  **應用最佳實踐**: 在你的新 Prompt 中，靈活運用以下一種或多種高級技巧來增強效果：
-    - **角色扮演 (Role-Playing)**: 明確指定 AI 扮演的角色。
-    - **結構化格式 (Structured Format)**: 使用 Markdown（如 #, ##, ###）來組織結構，例如 \`Role\`, \`Task\`, \`Context\`, \`Constraints\`, \`Output Format\` 等。
-    - **思維鏈 (Chain of Thought, CoT)**: 引導 AI 一步步思考。
-    - **提供範例 (Few-shot Examples)**: 給出輸入和輸出的範例，讓 AI 更好地理解期望。
-    - **明確的約束 (Constraints)**: 設定清晰的規則和限制，避免 AI 偏離主題。
-3.  **整合回饋**: 針對\`審核者回饋\`中的每一條建議，思考如何將其融入到新的 Prompt 中。
-4.  **輸出**: 只輸出**完整且可直接使用**的新 Prompt 內容，不要包含任何額外的解釋或對話。`,
-      critic: `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
-
-你的評估必須基於以下五個維度，每個維度滿分 100：
-1.  **清晰度 (Clarity)**: Prompt 是否清晰易懂，沒有歧義？
-2.  **具體性 (Specificity)**: 是否包含了足夠的細節和上下文，讓 AI 能準確執行任務？
-3.  **完整性 (Completeness)**: 是否考慮了任務的各個方面和潛在的邊界情況？
-4.  **穩健性 (Robustness)**: Prompt 是否足夠靈活，能應對輕微變化的輸入，而不是過於僵化？
-5.  **原意符合度 (Intent Adherence)**: 是否完全符合用戶的\`初始需求\`，沒有添加不相關或偏離核心目標的內容？
-
-你的工作流程是：
-1.  **比較**: 將\`待審核的 Prompt\`與用戶的\`初始需求\`進行比較，確保核心目標一致。
-2.  **評分**: 根據上述五個維度，獨立打分。
-3.  **計算總分**: \`overall_score\` 是五個維度分數的加權平均值 (原意符合度權重最高，例如 40%，其餘各 15%)。
-4.  **提供回饋**:
-    - \`feedback_summary\`: 用一句話總結你的整體看法。
-    - \`actionable_suggestions\`: 提供 2-3 條具體的、可立即執行的修改建議，用於指導下一個版本的改進。
-
-你的輸出必須是**嚴格的 JSON 格式**，結構如下：
-{
-  "scores": { "clarity": int, "specificity": int, "completeness": int, "robustness": int, "intent_adherence": int },
-  "overall_score": int,
-  "feedback_summary": "string",
-  "actionable_suggestions": ["string1", "string2", ...]
-}
-
-不要輸出任何 JSON 以外的內容。`,
-      chat: '請輸出繁體中文回覆'
-    }
-
-    setSystemPrompt(promptType, defaultPrompts[promptType])
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[95vw] max-w-[600px] max-h-[90vh] flex flex-col h-[90vh] !grid-cols-none !gap-0">
-        {/* Fixed Header and Status */}
+      <DialogContent className="flex h-[90vh] max-h-[90vh] w-[95vw] max-w-[720px] flex-col !grid-cols-none !gap-0 overflow-hidden">
         <div className="flex-shrink-0 space-y-4">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              Settings
-            </DialogTitle>
+            <DialogTitle className="flex items-center gap-2 text-lg">Settings</DialogTitle>
           </DialogHeader>
 
-          {/* Status lights - Fixed at top */}
-          <div className="grid grid-cols-2 gap-3 pb-3 border-b border-border">
-            {(['gemini','deepseek'] as const).map((p) => (
-              <div key={p} className="flex items-center gap-2">
-                <span className={cn(
-                  'inline-block w-2.5 h-2.5 rounded-full',
-                  connectionStatus[p] && 'bg-green-500',
-                  !connectionStatus[p] && 'bg-red-500'
-                )} />
-                <span className="text-sm">
-                  {p === 'gemini' ? 'Gemini AI Studio' : 'DeepSeek'}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {connectionStatus[p] ? 'Connected' : 'Not connected'}
-                  {connectionStatus.lastTested && (
-                    <span className="ml-1">
-                      ({new Date(connectionStatus.lastTested).toLocaleTimeString()})
-                    </span>
-                  )}
-                </span>
-              </div>
-            ))}
-          </div>
+          {feedback ? <FeedbackBanner feedback={feedback} onDismiss={dismissFeedback} /> : null}
+
+          <SettingsStatusHeader connectionStatus={connectionStatus} />
         </div>
 
-        {/* Scrollable content area - Everything below status lights */}
-        <div className="flex-1 overflow-y-auto pr-2 space-y-3 py-3">
-          {/* API Keys Section */}
-          <CollapsibleSection
-            title="API Keys"
-            icon={
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H7l5-4-5-4h4l2.257-2.257A6 6 0 0119 9z" />
-              </svg>
-            }
-            defaultExpanded={true}
-          >
-            <div className="space-y-4">
-              {/* Gemini */}
-              <div>
-                <label className="block text-sm font-medium mb-2">
-                  Gemini AI Studio API Key
-                </label>
-                <div className="flex gap-2">
-                  <input
-                    type="password"
-                    value={apiKeys.gemini}
-                    onChange={(e) => setApiKey('gemini', e.target.value)}
-                    placeholder="Enter your Gemini AI Studio API key"
-                    className="flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                  />
-                  <button
-                    onClick={() => handleTestConnection('gemini')}
-                    disabled={!apiKeys.gemini || isTesting}
-                    className={cn(
-                      'px-3 py-2 border border-border rounded-lg transition-colors',
-                      apiKeys.gemini && !isTesting
-                        ? 'hover:bg-accent'
-                        : 'opacity-50 cursor-not-allowed'
-                    )}
-                  >
-                    <TestTube className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
+        <div className="flex-1 space-y-3 overflow-y-auto pr-1 py-3">
+          <APIKeySection
+            apiKeys={apiKeys}
+            connectionStatus={connectionStatus}
+            onChangeKey={setApiKey}
+            onTestConnection={testProviderConnection}
+            isTesting={isTestingConnection}
+          />
 
-              {/* DeepSeek */}
-              <div>
-                <label className="block text-sm font-medium mb-2">
-                  DeepSeek API Key
-                </label>
-                <div className="flex gap-2">
-                  <input
-                    type="password"
-                    value={apiKeys.deepseek}
-                    onChange={(e) => setApiKey('deepseek', e.target.value)}
-                    placeholder="Enter your DeepSeek API key"
-                    className="flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                  />
-                  <button
-                    onClick={() => handleTestConnection('deepseek')}
-                    disabled={!apiKeys.deepseek || isTesting}
-                    className={cn(
-                      'px-3 py-2 border border-border rounded-lg transition-colors',
-                      apiKeys.deepseek && !isTesting
-                        ? 'hover:bg-accent'
-                        : 'opacity-50 cursor-not-allowed'
-                    )}
-                  >
-                    <TestTube className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </CollapsibleSection>
+          <ModelSettingsSection
+            modelSettings={modelSettings}
+            setModelSettings={setModelSettings}
+            availableModels={availableModels}
+            dynamicModels={dynamicModels}
+            userModelPreferences={userModelPreferences}
+            addPreferredModel={addPreferredModel}
+            removePreferredModel={removePreferredModel}
+            refreshModels={refreshModels}
+            isRefreshing={isRefreshingModels}
+          />
 
-          {/* Model Settings */}
-          <CollapsibleSection
-            title="Model Settings"
-            icon={
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-            }
-            defaultExpanded={true}
-          >
-            <div className="space-y-4">
-              {/* Default Provider */}
-              <div>
-                <label className="block text-sm font-medium mb-2">
-                  Default Provider
-                </label>
-                <select
-                  value={modelSettings.defaultProvider}
-                  onChange={(e) => setModelSettings({ defaultProvider: e.target.value as 'gemini' | 'deepseek' })}
-                  className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
-                >
-                  <option value="gemini">Gemini</option>
-                  <option value="deepseek">DeepSeek</option>
-                </select>
-              </div>
+          <SystemPromptSection systemPrompts={systemPrompts} setSystemPrompt={setSystemPrompt} />
 
-              {/* Default Model */}
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <label className="block text-sm font-medium">
-                      Default Model
-                    </label>
-                    <div title="Select your preferred models below. Removed models won't appear in dropdown menus.">
-                      <Info className="w-4 h-4 text-muted-foreground" />
-                    </div>
-                  </div>
-                  <button
-                    onClick={async () => {
-                      setIsRefreshingModels(true)
-                      try {
-                        const updatedModels = await refreshDynamicModels({
-                          gemini: apiKeys.gemini,
-                          deepseek: apiKeys.deepseek,
-                        })
-                        setDynamicModels(updatedModels)
-                        // Re-initialize preferences with new models
-                        const provider = modelSettings.defaultProvider
-                        const allModels = updatedModels[provider] || []
-                        if (allModels.length > 0) {
-                          allModels.forEach(model => addPreferredModel(provider, model))
-                        }
-                      } catch (error) {
-                        console.warn('Failed to refresh models:', error)
-                      } finally {
-                        setIsRefreshingModels(false)
-                      }
-                    }}
-                    disabled={isRefreshingModels}
-                    className={cn(
-                      'p-1 rounded-md transition-colors',
-                      isRefreshingModels
-                        ? 'opacity-50 cursor-not-allowed'
-                        : 'hover:bg-accent text-muted-foreground hover:text-foreground'
-                    )}
-                    title="Refresh available models"
-                  >
-                    <RefreshCw className={cn(
-                      'w-4 h-4',
-                      isRefreshingModels && 'animate-spin'
-                    )} />
-                  </button>
-                </div>
+          <FeatureToggleSection features={features} setFeature={setFeature} />
 
-                {/* Current Default Model Selector */}
-                <div className="mb-3">
-                  <label className="block text-xs text-muted-foreground mb-1">
-                    Current Default Model
-                  </label>
-                  <select
-                    value={modelSettings.defaultModel}
-                    onChange={(e) => setModelSettings({ defaultModel: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm"
-                  >
-                    {availableModels.map((m) => (
-                      <option key={m} value={m}>{m}</option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Model Preferences */}
-                <div>
-                  <label className="block text-xs text-muted-foreground mb-2">
-                    Manage Available Models (click × to remove)
-                  </label>
-                  <div className="max-h-32 overflow-y-auto border border-border rounded-lg p-2 space-y-1">
-                    {dynamicModels[modelSettings.defaultProvider]?.map((model) => {
-                      const isPreferred = userModelPreferences[modelSettings.defaultProvider]?.includes(model)
-                      return (
-                        <div key={model} className="flex items-center justify-between py-1 px-2 rounded text-sm hover:bg-accent/50">
-                          <span className={cn(
-                            'flex-1 truncate',
-                            isPreferred ? 'text-foreground' : 'text-muted-foreground'
-                          )}>
-                            {model}
-                          </span>
-                          <button
-                            onClick={() => {
-                              if (isPreferred) {
-                                removePreferredModel(modelSettings.defaultProvider, model)
-                              } else {
-                                addPreferredModel(modelSettings.defaultProvider, model)
-                              }
-                            }}
-                            className={cn(
-                              'ml-2 p-1 rounded transition-colors',
-                              isPreferred
-                                ? 'hover:bg-destructive hover:text-destructive-foreground text-muted-foreground'
-                                : 'hover:bg-primary hover:text-primary-foreground text-muted-foreground'
-                            )}
-                            title={isPreferred ? 'Remove from available models' : 'Add to available models'}
-                          >
-                            <X className="w-3 h-3" />
-                          </button>
-                        </div>
-                      )
-                    })}
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Only preferred models will appear in dropdown menus throughout the app.
-                  </p>
-                </div>
-              </div>
-
-              {/* Temperature */}
-              <div>
-                <label className="block text-sm font-medium mb-2">
-                  Temperature: {modelSettings.temperature}
-                </label>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.1"
-                  value={modelSettings.temperature}
-                  onChange={(e) => setModelSettings({ temperature: parseFloat(e.target.value) })}
-                  className="w-full"
-                />
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>More deterministic</span>
-                  <span>More creative</span>
-                </div>
-              </div>
-            </div>
-          </CollapsibleSection>
-
-          {/* System Prompts Section */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">System Prompts</h3>
-
-            <div className="space-y-4">
-              {/* Prompt Optimizer Category */}
-              <CollapsibleSection
-                title="Prompt Optimizer"
-                icon={
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                  </svg>
-                }
-                defaultExpanded={false}
-              >
-                <div className="space-y-4 pl-6">
-                  {/* Improver Prompt */}
-                  <div className="border-l-2 border-primary/20 pl-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="block text-sm font-medium text-primary">
-                        Improver Prompt
-                      </label>
-                      <button
-                        onClick={() => restoreDefaultPrompt('improver')}
-                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        Restore Default
-                      </button>
-                    </div>
-                    <textarea
-                      value={systemPrompts.improver}
-                      onChange={(e) => setSystemPrompt('improver', e.target.value)}
-                      rows={4}
-                      className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary font-mono text-sm"
-                      placeholder="Enter Improver system prompt"
-                    />
-                  </div>
-
-                  {/* Critic Prompt */}
-                  <div className="border-l-2 border-primary/20 pl-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="block text-sm font-medium text-primary">
-                        Critic Prompt
-                      </label>
-                      <button
-                        onClick={() => restoreDefaultPrompt('critic')}
-                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        Restore Default
-                      </button>
-                    </div>
-                    <textarea
-                      value={systemPrompts.critic}
-                      onChange={(e) => setSystemPrompt('critic', e.target.value)}
-                      rows={4}
-                      className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary font-mono text-sm"
-                      placeholder="Enter Critic system prompt"
-                    />
-                  </div>
-                </div>
-              </CollapsibleSection>
-
-              {/* Chat Category */}
-              <CollapsibleSection
-                title="Chat"
-                icon={
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                  </svg>
-                }
-                defaultExpanded={false}
-              >
-                <div className="space-y-4 pl-6">
-                  {/* Chat System Prompt */}
-                  <div className="border-l-2 border-green-500/20 pl-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="block text-sm font-medium text-green-600">
-                        Chat System Prompt
-                      </label>
-                      <button
-                        onClick={() => setSystemPrompt('chat', '請輸出繁體中文回覆')}
-                        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        Restore Default
-                      </button>
-                    </div>
-                    <textarea
-                      value={systemPrompts.chat || '請輸出繁體中文回覆'}
-                      onChange={(e) => setSystemPrompt('chat', e.target.value)}
-                      rows={3}
-                      className="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 font-mono text-sm"
-                      placeholder="請輸出繁體中文回覆"
-                    />
-                  </div>
-                </div>
-              </CollapsibleSection>
-            </div>
-          </div>
-
-          {/* Feature Toggles */}
-          <div>
-            <h3 className="text-lg font-semibold mb-4">Features</h3>
-
-            <div className="space-y-3">
-              {/* Show Token Usage */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Show Token Usage
-                  </label>
-                  <p className="text-xs text-muted-foreground">
-                    Display token counts in chat interface
-                  </p>
-                </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={features.showTokenUsage}
-                    onChange={(e) => setFeature('showTokenUsage', e.target.checked)}
-                    className="sr-only peer"
-                  />
-                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/25 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
-                </label>
-              </div>
-
-              {/* Enable Gemini Cache */}
-              <div className="flex items-center justify-between">
-                <div>
-                  <label className="block text-sm font-medium mb-1">
-                    Enable Gemini Cache
-                  </label>
-                  <p className="text-xs text-muted-foreground">
-                    Use caching to reduce API costs (Gemini only)
-                  </p>
-                </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={features.enableGeminiCache}
-                    onChange={(e) => setFeature('enableGeminiCache', e.target.checked)}
-                    className="sr-only peer"
-                  />
-                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/25 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
-                </label>
-              </div>
-            </div>
-
-            {/* Footer Actions - Inside scrollable area */}
-            <div className="flex justify-between items-center pt-4 border-t border-border">
-              <button
-                onClick={handleManualSync}
-                disabled={isSyncing}
-                className={cn(
-                  'flex items-center gap-2 px-4 py-2 border border-border rounded-lg transition-colors',
-                  isSyncing
-                    ? 'opacity-50 cursor-not-allowed'
-                    : 'hover:bg-accent'
-                )}
-                title="Sync data with server"
-              >
-                <Cloud className={cn(
-                  'w-4 h-4',
-                  isSyncing && 'animate-spin'
-                )} />
-                {isSyncing ? 'Syncing...' : 'Sync Data'}
-              </button>
-
-              <div className="flex gap-3">
-                <button
-                  onClick={() => onOpenChange(false)}
-                  className="px-4 py-2 border border-border rounded-lg hover:bg-accent transition-colors"
-                >
-                  Cancel
-                </button>
-
-                <button
-                  onClick={handleSave}
-                  className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
-                >
-                  <Save className="w-4 h-4" />
-                  Save Settings
-                </button>
-              </div>
-            </div>
-          </div>
+          <SettingsFooter
+            onClose={() => onOpenChange(false)}
+            onSave={handleSave}
+            onManualSync={handleManualSync}
+            isSyncing={isSyncing}
+          />
         </div>
       </DialogContent>
     </Dialog>
   )
 }
+

--- a/src/components/settings/SettingsStatusHeader.tsx
+++ b/src/components/settings/SettingsStatusHeader.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { Settings } from '@/store/settingsStore'
+
+interface SettingsStatusHeaderProps {
+  connectionStatus: Settings['connectionStatus']
+}
+
+const providerLabels: Record<'gemini' | 'deepseek', string> = {
+  gemini: 'Gemini AI Studio',
+  deepseek: 'DeepSeek',
+}
+
+export function SettingsStatusHeader({ connectionStatus }: SettingsStatusHeaderProps) {
+  return (
+    <div className="grid grid-cols-1 gap-3 border-b border-border pb-3 text-sm sm:grid-cols-2">
+      {(['gemini', 'deepseek'] as const).map((provider) => (
+        <div key={provider} className="flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full ${connectionStatus[provider] ? 'bg-green-500' : 'bg-red-500'}`}
+            aria-hidden
+          />
+          <span className="font-medium">{providerLabels[provider]}</span>
+          <span className="text-xs text-muted-foreground">
+            {connectionStatus[provider] ? 'Connected' : 'Not connected'}
+            {connectionStatus.lastTested ? (
+              <span className="ml-1">
+                ({new Date(connectionStatus.lastTested).toLocaleTimeString()})
+              </span>
+            ) : null}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/src/components/settings/SystemPromptSection.tsx
+++ b/src/components/settings/SystemPromptSection.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { CollapsibleSection } from './CollapsibleSection'
+import type { Settings } from '@/store/settingsStore'
+import { DEFAULT_SYSTEM_PROMPTS } from './defaultPrompts'
+
+interface SystemPromptSectionProps {
+  systemPrompts: Settings['systemPrompts']
+  setSystemPrompt: (type: keyof Settings['systemPrompts'], prompt: string) => void
+}
+
+export function SystemPromptSection({ systemPrompts, setSystemPrompt }: SystemPromptSectionProps) {
+  const groups: { key: keyof Settings['systemPrompts']; title: string; accent: string }[] = [
+    { key: 'improver', title: 'Improver System Prompt', accent: 'border-blue-500/30' },
+    { key: 'critic', title: 'Critic System Prompt', accent: 'border-purple-500/30' },
+    { key: 'chat', title: 'Chat System Prompt', accent: 'border-green-500/30' },
+  ]
+
+  return (
+    <CollapsibleSection
+      title="System Prompts"
+      icon={<svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 4c-2.21 0-4 1.79-4 4v2h8v-2c0-2.21-1.79-4-4-4z" /></svg>}
+      defaultExpanded
+    >
+      <div className="space-y-4">
+        {groups.map(({ key, title, accent }) => (
+          <div key={key} className={`rounded-lg border-l-2 ${accent} bg-muted/30 p-4`}>
+            <div className="mb-2 flex items-center justify-between">
+              <label className="text-sm font-medium" htmlFor={`${key}-prompt`}>
+                {title}
+              </label>
+              <button
+                type="button"
+                onClick={() => setSystemPrompt(key, DEFAULT_SYSTEM_PROMPTS[key])}
+                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                Restore Default
+              </button>
+            </div>
+            <textarea
+              id={`${key}-prompt`}
+              value={systemPrompts[key] || DEFAULT_SYSTEM_PROMPTS[key]}
+              onChange={(event) => setSystemPrompt(key, event.target.value)}
+              rows={key === 'chat' ? 3 : 6}
+              className="w-full rounded-lg border border-border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  )
+}
+

--- a/src/components/settings/defaultPrompts.ts
+++ b/src/components/settings/defaultPrompts.ts
@@ -1,0 +1,42 @@
+export const DEFAULT_SYSTEM_PROMPTS = {
+  improver: `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
+
+你的工作流程是：
+1.  **分析輸入**: 仔細理解用戶的\`初始需求\`、\`當前 Prompt 版本\`以及\`審核者回饋\`。
+2.  **應用最佳實踐**: 在你的新 Prompt 中，靈活運用以下一種或多種高級技巧來增強效果：
+    - **角色扮演 (Role-Playing)**: 明確指定 AI 扮演的角色。
+    - **結構化格式 (Structured Format)**: 使用 Markdown（如 #, ##, ###）來組織結構，例如 \`Role\`, \`Task\`, \`Context\`, \`Constraints\`, \`Output Format\` 等。
+    - **思維鏈 (Chain of Thought, CoT)**: 引導 AI 一步步思考。
+    - **提供範例 (Few-shot Examples)**: 給出輸入和輸出的範例，讓 AI 更好地理解期望。
+    - **明確的約束 (Constraints)**: 設定清晰的規則和限制，避免 AI 偏離主題。
+3.  **整合回饋**: 針對\`審核者回饋\`中的每一條建議，思考如何將其融入到新的 Prompt 中。
+4.  **輸出**: 只輸出**完整且可直接使用**的新 Prompt 內容，不要包含任何額外的解釋或對話。`,
+  critic: `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
+
+你的評估必須基於以下五個維度，每個維度滿分 100：
+1.  **清晰度 (Clarity)**: Prompt 是否清晰易懂，沒有歧義？
+2.  **具體性 (Specificity)**: 是否包含了足夠的細節和上下文，讓 AI 能準確執行任務？
+3.  **完整性 (Completeness)**: 是否考慮了任務的各個方面和潛在的邊界情況？
+4.  **穩健性 (Robustness)**: Prompt 是否足夠靈活，能應對輕微變化的輸入，而不是過於僵化？
+5.  **原意符合度 (Intent Adherence)**: 是否完全符合用戶的\`初始需求\`，沒有添加不相關或偏離核心目標的內容？
+
+你的工作流程是：
+1.  **比較**: 將\`待審核的 Prompt\`與用戶的\`初始需求\`進行比較，確保核心目標一致。
+2.  **評分**: 根據上述五個維度，獨立打分。
+3.  **計算總分**: \`overall_score\` 是五個維度分數的加權平均值 (原意符合度權重最高，例如 40%，其餘各 15%)。
+4.  **提供回饋**:
+    - \`feedback_summary\`: 用一句話總結你的整體看法。
+    - \`actionable_suggestions\`: 提供 2-3 條具體的、可立即執行的修改建議，用於指導下一個版本的改進。
+
+你的輸出必須是**嚴格的 JSON 格式**，結構如下：
+{
+  "scores": { "clarity": int, "specificity": int, "completeness": int, "robustness": int, "intent_adherence": int },
+  "overall_score": int,
+  "feedback_summary": "string",
+  "actionable_suggestions": ["string1", "string2", ...]
+}
+
+不要輸出任何 JSON 以外的內容。`,
+  chat: '請輸出繁體中文回覆',
+}
+

--- a/src/components/ui/AnimationDemo.tsx
+++ b/src/components/ui/AnimationDemo.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import AnimatedButton, { SmoothButton, RippleButton, PressButton, PulseButton } from './AnimatedButton'
+import { SmoothButton, RippleButton, PressButton, PulseButton } from './AnimatedButton'
 
 export default function AnimationDemo() {
   const [message, setMessage] = useState('')

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    return window.matchMedia(query).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mediaQuery = window.matchMedia(query)
+    const listener = (event: MediaQueryListEvent) => {
+      setMatches(event.matches)
+    }
+
+    setMatches(mediaQuery.matches)
+    mediaQuery.addEventListener('change', listener)
+
+    return () => mediaQuery.removeEventListener('change', listener)
+  }, [query])
+
+  return matches
+}
+

--- a/src/hooks/useSettingsModal.ts
+++ b/src/hooks/useSettingsModal.ts
@@ -1,0 +1,241 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSettingsStore } from '@/store/settingsStore'
+import { getModelOptions, refreshDynamicModels, type ProviderName } from '@/lib/providers'
+import { manualSync } from '@/lib/syncManager'
+
+export type SettingsFeedbackType = 'success' | 'error' | 'warning'
+
+export interface SettingsFeedback {
+  type: SettingsFeedbackType
+  title: string
+  description?: string
+}
+
+type DynamicModels = Record<ProviderName, string[]>
+
+const providerLabels: Record<ProviderName, string> = {
+  gemini: 'Gemini AI Studio',
+  deepseek: 'DeepSeek',
+}
+
+export function useSettingsModal(isOpen: boolean) {
+  const {
+    apiKeys,
+    modelSettings,
+    systemPrompts,
+    features,
+    connectionStatus,
+    userModelPreferences,
+    setApiKey,
+    setModelSettings,
+    setSystemPrompt,
+    setFeature,
+    testConnections,
+    addPreferredModel,
+    removePreferredModel,
+    setConnectionStatus,
+  } = useSettingsStore()
+
+  const [dynamicModels, setDynamicModels] = useState<DynamicModels>(() => getModelOptions())
+  const [isRefreshingModels, setIsRefreshingModels] = useState(false)
+  const [isTestingConnection, setIsTestingConnection] = useState<ProviderName | null>(null)
+  const [isSyncing, setIsSyncing] = useState(false)
+  const [feedback, setFeedback] = useState<SettingsFeedback | null>(null)
+
+  const dismissFeedback = useCallback(() => setFeedback(null), [])
+
+  const filterModelsByPreference = useCallback(
+    (provider: ProviderName, availableModels: string[]) => {
+      const preferredModels = userModelPreferences[provider] || []
+      if (preferredModels.length === 0) return availableModels
+      return availableModels.filter((model) => preferredModels.includes(model))
+    },
+    [userModelPreferences]
+  )
+
+  const availableModels = useMemo(() => {
+    const modelsForProvider = dynamicModels[modelSettings.defaultProvider] || []
+    return filterModelsByPreference(modelSettings.defaultProvider, modelsForProvider)
+  }, [dynamicModels, modelSettings.defaultProvider, filterModelsByPreference])
+
+  const ensurePreferenceDefaults = useCallback(
+    (provider: ProviderName, models: string[]) => {
+      const currentPreferences = userModelPreferences[provider]
+      if (currentPreferences.length === 0 && models.length > 0) {
+        models.forEach((model) => addPreferredModel(provider, model))
+      }
+    },
+    [addPreferredModel, userModelPreferences]
+  )
+
+  const refreshModels = useCallback(async () => {
+    setIsRefreshingModels(true)
+    try {
+      const updated = await refreshDynamicModels({
+        gemini: apiKeys.gemini,
+        deepseek: apiKeys.deepseek,
+      })
+      setDynamicModels(updated)
+      ensurePreferenceDefaults(modelSettings.defaultProvider, updated[modelSettings.defaultProvider] || [])
+      setFeedback({
+        type: 'success',
+        title: 'Model list updated',
+        description: 'Latest provider models were fetched successfully.',
+      })
+      return updated
+    } catch (error) {
+      console.warn('Failed to refresh models:', error)
+      setFeedback({
+        type: 'warning',
+        title: 'Unable to refresh provider models',
+        description: 'Using cached or fallback models until the network issue is resolved.',
+      })
+      return dynamicModels
+    } finally {
+      setIsRefreshingModels(false)
+    }
+  }, [apiKeys.deepseek, apiKeys.gemini, dynamicModels, ensurePreferenceDefaults, modelSettings.defaultProvider])
+
+  const testProviderConnection = useCallback(
+    async (provider: ProviderName) => {
+      const apiKey = apiKeys[provider]
+      if (!apiKey) return
+
+      setIsTestingConnection(provider)
+      try {
+        const response = await fetch('/api/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ provider, apiKey }),
+        })
+
+        const result = await response.json()
+
+        if (result.success) {
+          setConnectionStatus(provider, true)
+          setFeedback({
+            type: 'success',
+            title: `${providerLabels[provider]} connection verified`,
+            description: result.message,
+          })
+
+          const saveResponse = await fetch('/api/keys', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ provider, apiKey }),
+          })
+
+          if (!saveResponse.ok && saveResponse.status !== 401) {
+            setFeedback({
+              type: 'warning',
+              title: 'Key verification succeeded but saving failed',
+              description: 'Please try again after confirming your session is still active.',
+            })
+          }
+
+          await testConnections()
+        } else {
+          setConnectionStatus(provider, false)
+          setFeedback({
+            type: 'error',
+            title: `${providerLabels[provider]} connection failed`,
+            description: result.message,
+          })
+        }
+      } catch (error) {
+        console.error('Connection test failed:', error)
+        setConnectionStatus(provider, false)
+        setFeedback({
+          type: 'error',
+          title: `${providerLabels[provider]} connection failed`,
+          description: 'Network error occurred while attempting to reach the provider.',
+        })
+      } finally {
+        setIsTestingConnection(null)
+      }
+    },
+    [apiKeys, setConnectionStatus, testConnections]
+  )
+
+  const handleManualSync = useCallback(async () => {
+    setIsSyncing(true)
+    try {
+      const result = await manualSync()
+      if (result.settingsConflict || result.appStateConflict) {
+        setFeedback({
+          type: 'warning',
+          title: 'Sync completed with conflicts',
+          description: 'Please review your latest data to ensure everything looks correct.',
+        })
+      } else {
+        setFeedback({
+          type: 'success',
+          title: 'Sync completed',
+          description: 'Your settings are now in sync with the server.',
+        })
+      }
+    } catch (error) {
+      console.error('Manual sync failed:', error)
+      setFeedback({
+        type: 'error',
+        title: 'Sync failed',
+        description: 'Check your network connection or sign in again before retrying.',
+      })
+    } finally {
+      setIsSyncing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    refreshModels().catch((error) => {
+      console.error('Initial model refresh failed:', error)
+    })
+
+    testConnections().catch((error) => {
+      console.error('Initial connection test failed:', error)
+    })
+  }, [isOpen, refreshModels, testConnections])
+
+  useEffect(() => {
+    if (!availableModels.includes(modelSettings.defaultModel) && availableModels.length > 0) {
+      setModelSettings({ defaultModel: availableModels[0] })
+    }
+  }, [availableModels, modelSettings.defaultModel, setModelSettings])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const provider = modelSettings.defaultProvider
+    const models = dynamicModels[provider] || []
+    ensurePreferenceDefaults(provider, models)
+  }, [dynamicModels, ensurePreferenceDefaults, isOpen, modelSettings.defaultProvider])
+
+  return {
+    apiKeys,
+    modelSettings,
+    systemPrompts,
+    features,
+    connectionStatus,
+    userModelPreferences,
+    setApiKey,
+    setModelSettings,
+    setSystemPrompt,
+    setFeature,
+    addPreferredModel,
+    removePreferredModel,
+    availableModels,
+    dynamicModels,
+    isRefreshingModels,
+    isTestingConnection,
+    isSyncing,
+    feedback,
+    dismissFeedback,
+    refreshModels,
+    testProviderConnection,
+    handleManualSync,
+  }
+}
+

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -124,6 +124,7 @@ interface AppState {
   syncStatus: 'idle' | 'syncing' | 'success' | 'error'
   lastSyncAt: number | null
   setSyncStatus: (status: AppState['syncStatus']) => void
+  resetState: () => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -605,6 +606,17 @@ export const useAppStore = create<AppState>()(
 
       // Sync functionality
       setSyncStatus: (syncStatus) => set({ syncStatus }),
+
+      resetState: () => set({
+        tabs: [],
+        activeTab: null,
+        chatStates: {},
+        optimizerStates: {},
+        aipkStates: {},
+        file2fileStates: {},
+        syncStatus: 'idle',
+        lastSyncAt: null,
+      }),
 
       syncToServer: async (forceOverwrite = false) => {
         try {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { initializeSync, resetSync } from '@/lib/syncManager'
 
 interface SyncResult {
   conflict?: boolean
@@ -50,6 +49,7 @@ interface SettingsState extends Settings {
   testConnections: () => Promise<void>
   setConnectionStatus: (provider: 'gemini' | 'deepseek', status: boolean) => void
   resetToDefaults: () => void
+  clearSensitiveData: () => void
   // User model preferences
   addPreferredModel: (provider: 'gemini' | 'deepseek', model: string) => void
   removePreferredModel: (provider: 'gemini' | 'deepseek', model: string) => void
@@ -202,6 +202,17 @@ export const useSettingsStore = create<SettingsState>()(
 
       resetToDefaults: () => set(defaultSettings),
 
+      clearSensitiveData: () => set(() => ({
+        apiKeys: { gemini: '', deepseek: '' },
+        connectionStatus: {
+          gemini: false,
+          deepseek: false,
+          lastTested: 0,
+        },
+        lastSyncAt: null,
+        syncStatus: 'idle',
+      })),
+
       // User model preferences methods
       addPreferredModel: (provider, model) => {
         set((state) => ({
@@ -313,7 +324,6 @@ export const useSettingsStore = create<SettingsState>()(
       name: 'synapse-settings',
       // 排除同步狀態不持久化，只保留設定資料
       partialize: (state) => ({
-        apiKeys: state.apiKeys,
         modelSettings: state.modelSettings,
         systemPrompts: state.systemPrompts,
         features: state.features,


### PR DESCRIPTION
## Summary
- refactor the settings modal into modular sections backed by a dedicated hook with inline feedback and safer API key handling
- add responsive navigation by adapting the sidebar for mobile, lazy-loading heavy modals, and introducing a media query hook
- clean up lint warnings by pruning unused imports, improving auth logging, and clearing invalid auth cookies in middleware

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e152abe6dc833290125709578f2362