### PR TITLE
Fix settings modal refresh loop

### DIFF
--- a/src/hooks/useSettingsModal.ts
+++ b/src/hooks/useSettingsModal.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSettingsStore } from '@/store/settingsStore'
 import { getModelOptions, refreshDynamicModels, type ProviderName } from '@/lib/providers'
 import { manualSync } from '@/lib/syncManager'
@@ -43,6 +43,11 @@ export function useSettingsModal(isOpen: boolean) {
   const [isTestingConnection, setIsTestingConnection] = useState<ProviderName | null>(null)
   const [isSyncing, setIsSyncing] = useState(false)
   const [feedback, setFeedback] = useState<SettingsFeedback | null>(null)
+  const dynamicModelsRef = useRef<DynamicModels>(dynamicModels)
+
+  useEffect(() => {
+    dynamicModelsRef.current = dynamicModels
+  }, [dynamicModels])
 
   const dismissFeedback = useCallback(() => setFeedback(null), [])
 
@@ -92,11 +97,11 @@ export function useSettingsModal(isOpen: boolean) {
         title: 'Unable to refresh provider models',
         description: 'Using cached or fallback models until the network issue is resolved.',
       })
-      return dynamicModels
+      return dynamicModelsRef.current || getModelOptions()
     } finally {
       setIsRefreshingModels(false)
     }
-  }, [apiKeys.deepseek, apiKeys.gemini, dynamicModels, ensurePreferenceDefaults, modelSettings.defaultProvider])
+  }, [apiKeys.deepseek, apiKeys.gemini, ensurePreferenceDefaults, modelSettings.defaultProvider])
 
   const testProviderConnection = useCallback(
     async (provider: ProviderName) => {


### PR DESCRIPTION
## Summary
- prevent the settings modal refresh handler from being recreated after every dynamic model update, avoiding repeated refresh attempts when the dialog opens
- cache the latest dynamic models reference so we can safely fall back to the last successful list when refresh calls fail

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1658360bc83328195183668c722f9