### PR TITLE
Persist user settings and app state updates automatically

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("DATABASE_URL")
+  url       = env("VERCEL_POSTGRES_PRISMA_DATABASE_URL")
   directUrl = env("DIRECT_URL")
 }
 

--- a/src/hooks/useSettingsModal.ts
+++ b/src/hooks/useSettingsModal.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSettingsStore } from '@/store/settingsStore'
 import { getModelOptions, refreshDynamicModels, type ProviderName } from '@/lib/providers'
 import { manualSync } from '@/lib/syncManager'
@@ -43,6 +43,11 @@ export function useSettingsModal(isOpen: boolean) {
   const [isTestingConnection, setIsTestingConnection] = useState<ProviderName | null>(null)
   const [isSyncing, setIsSyncing] = useState(false)
   const [feedback, setFeedback] = useState<SettingsFeedback | null>(null)
+  const dynamicModelsRef = useRef<DynamicModels>(dynamicModels)
+
+  useEffect(() => {
+    dynamicModelsRef.current = dynamicModels
+  }, [dynamicModels])
 
   const dismissFeedback = useCallback(() => setFeedback(null), [])
 
@@ -92,11 +97,11 @@ export function useSettingsModal(isOpen: boolean) {
         title: 'Unable to refresh provider models',
         description: 'Using cached or fallback models until the network issue is resolved.',
       })
-      return dynamicModels
+      return dynamicModelsRef.current || getModelOptions()
     } finally {
       setIsRefreshingModels(false)
     }
-  }, [apiKeys.deepseek, apiKeys.gemini, dynamicModels, ensurePreferenceDefaults, modelSettings.defaultProvider])
+  }, [apiKeys.deepseek, apiKeys.gemini, ensurePreferenceDefaults, modelSettings.defaultProvider])
 
   const testProviderConnection = useCallback(
     async (provider: ProviderName) => {

--- a/src/lib/autoSync.ts
+++ b/src/lib/autoSync.ts
@@ -1,0 +1,48 @@
+export type AutoSyncTask = () => Promise<void>
+
+interface AutoSyncOptions {
+  delay?: number
+  taskName?: string
+}
+
+export function createAutoSyncScheduler(task: AutoSyncTask, options: AutoSyncOptions = {}) {
+  const { delay = 800, taskName = 'auto-sync' } = options
+
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  let inFlight = false
+  let pending = false
+
+  const run = async () => {
+    timeout = null
+
+    if (inFlight) {
+      pending = true
+      return
+    }
+
+    inFlight = true
+    pending = false
+    try {
+      await task()
+    } catch (error) {
+      console.error(`[${taskName}] failed:`, error)
+    } finally {
+      inFlight = false
+      if (pending) {
+        schedule()
+      }
+    }
+  }
+
+  const schedule = () => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+    timeout = setTimeout(run, delay)
+  }
+
+  return () => {
+    pending = true
+    schedule()
+  }
+}


### PR DESCRIPTION
## Summary
- switch the Prisma datasource to Vercel's managed Postgres connection variable
- add a reusable auto-sync scheduler and hook settings/app stores to persist user changes automatically with server version tracking
- record server-provided sync metadata so data reloads consistently across sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1658360bc83328195183668c722f9