### PR TITLE
Ensure optimizer uses custom prompts and expand settings view

### DIFF
--- a/src/components/core/OptimizerInterface.tsx
+++ b/src/components/core/OptimizerInterface.tsx
@@ -14,7 +14,7 @@ interface OptimizerInterfaceProps {
 
 export default function OptimizerInterface({ tabId }: OptimizerInterfaceProps) {
   const { optimizerStates, setOptimizerInitialPrompt, addOptimizerRound, setOptimizerBestResult, resetOptimizerProgress } = useAppStore()
-  const { modelSettings, apiKeys } = useSettingsStore()
+  const { modelSettings, apiKeys, systemPrompts } = useSettingsStore()
   const [input, setInput] = useState('')
   const [isOptimizing, setIsOptimizing] = useState(false)
   const [currentRound, setCurrentRound] = useState(0)
@@ -53,6 +53,7 @@ export default function OptimizerInterface({ tabId }: OptimizerInterfaceProps) {
           threshold: 90,
           provider,
           apiKey: selectedKey,
+          systemPrompts,
         }),
       })
 

--- a/src/components/settings/CollapsibleSection.tsx
+++ b/src/components/settings/CollapsibleSection.tsx
@@ -40,7 +40,7 @@ export function CollapsibleSection({ title, icon, defaultExpanded = false, child
       <div
         className={cn(
           'overflow-hidden transition-all duration-300 ease-in-out',
-          isExpanded ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0'
+          isExpanded ? 'max-h-[56rem] opacity-100' : 'max-h-0 opacity-0'
         )}
       >
         <div className="p-4 bg-background">{children}</div>

--- a/src/components/settings/SystemPromptSection.tsx
+++ b/src/components/settings/SystemPromptSection.tsx
@@ -41,7 +41,7 @@ export function SystemPromptSection({ systemPrompts, setSystemPrompt }: SystemPr
               id={`${key}-prompt`}
               value={systemPrompts[key] || DEFAULT_SYSTEM_PROMPTS[key]}
               onChange={(event) => setSystemPrompt(key, event.target.value)}
-              rows={key === 'chat' ? 3 : 6}
+              rows={key === 'chat' ? 6 : 10}
               className="w-full rounded-lg border border-border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
             />
           </div>


### PR DESCRIPTION
## Summary
- include the configured system prompts in optimizer requests so improvements reflect the chosen instructions
- increase the settings collapsible max height to avoid truncating the system prompt editors
- enlarge the system prompt text areas for easier editing of long prompts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e602fd6b608332805d890216a4d10e