### PR TITLE
Respect optimizer model settings

### DIFF
--- a/src/components/core/OptimizerInterface.tsx
+++ b/src/components/core/OptimizerInterface.tsx
@@ -54,6 +54,8 @@ export default function OptimizerInterface({ tabId }: OptimizerInterfaceProps) {
           provider,
           apiKey: selectedKey,
           systemPrompts,
+          model: modelSettings.defaultModel,
+          temperature: modelSettings.temperature,
         }),
       })
 


### PR DESCRIPTION
## Summary
- allow the optimizer API to use the user-selected model, temperature, and max token settings instead of a hard-coded default
- forward the selected model and temperature from the client when starting an optimization run
- ensure reviewer feedback generation respects the configured model while keeping deterministic scoring settings

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e609a3663c833285338844ad5c9c38