### PR TITLE
Fix Gemini optimizer flow and simplify system prompts

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -12,13 +12,7 @@ type ReviewAnalysis = {
   feedback: string[]
 }
 
-// 優化器邏輯
-class OptimizerClient {
-  private improverPrompt: string
-  private criticPrompt: string
-
-  constructor(improverPrompt?: string, criticPrompt?: string) {
-    this.improverPrompt = improverPrompt || `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
+const IMPROVER_SYSTEM_PROMPT = `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
 
 你的工作流程是：
 1.  **分析輸入**: 仔細理解用戶的\`初始需求\`、\`當前 Prompt 版本\`以及\`審核者回饋\`。
@@ -30,8 +24,8 @@ class OptimizerClient {
     - **明確的約束 (Constraints)**: 設定清晰的規則和限制，避免 AI 偏離主題。
 3.  **整合回饋**: 針對\`審核者回饋\`中的每一條建議，思考如何將其融入到新的 Prompt 中。
 4.  **輸出**: 只輸出**完整且可直接使用**的新 Prompt 內容，不要包含任何額外的解釋或對話。`
-    
-    this.criticPrompt = criticPrompt || `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
+
+const CRITIC_SYSTEM_PROMPT = `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
 
 你的評估必須基於以下五個維度，每個維度滿分 100：
 1.  **清晰度 (Clarity)**: Prompt 是否清晰易懂，沒有歧義？
@@ -44,7 +38,7 @@ class OptimizerClient {
 1.  **比較**: 將\`待審核的 Prompt\`與用戶的\`初始需求\`進行比較，確保核心目標一致。
 2.  **評分**: 根據上述五個維度，獨立打分。
 3.  **計算總分**: \`overall_score\` 是五個維度分數的加權平均值 (原意符合度權重最高，例如 40%，其餘各 15%)。
-4.  **提供回饋**: 
+4.  **提供回饋**:
     - \`feedback_summary\`: 用一句話總結你的整體看法。
     - \`actionable_suggestions\`: 提供 2-3 條具體的、可立即執行的修改建議，用於指導下一個版本的改進。
 
@@ -53,27 +47,39 @@ class OptimizerClient {
   "scores": { "clarity": int, "specificity": int, "completeness": int, "robustness": int, "intent_adherence": int },
   "overall_score": int,
   "feedback_summary": "string",
-  "actionable_suggestions": ["string1", "string2", ...]
+ "actionable_suggestions": ["string1", "string2", ...]
 }
 
 不要輸出任何 JSON 以外的內容。`
-  }
+
+// 優化器邏輯
+class OptimizerClient {
+  private improverPrompt = IMPROVER_SYSTEM_PROMPT
+  private criticPrompt = CRITIC_SYSTEM_PROMPT
 
   async optimizePrompt(
     initialPrompt: string,
     currentPrompt: string,
     previousFeedback: string[],
     provider: string,
-    apiKey?: string
+    apiKey: string | undefined,
+    options?: {
+      model?: string
+      temperature?: number
+      maxTokens?: number
+    }
   ) {
-    try {
-      const sanitizedInitial = initialPrompt.trim()
-      const sanitizedCurrent = currentPrompt.trim() || sanitizedInitial
-      const feedbackSection = previousFeedback.length
-        ? previousFeedback.map((item, index) => `${index + 1}. ${item}`).join('\n')
-        : '目前尚未收到審核回饋，請根據初始需求自行優化。'
+    const sanitizedInitial = initialPrompt.trim()
+    const sanitizedCurrent = currentPrompt.trim() || sanitizedInitial
+    const feedbackSection = previousFeedback.length
+      ? previousFeedback.map((item, index) => `${index + 1}. ${item}`).join('\n')
+      : '目前尚未收到審核回饋，請根據初始需求自行優化。'
 
-      const optimizationPrompt = `${this.improverPrompt}
+    const messages = [
+      { role: 'system' as const, content: this.improverPrompt },
+      {
+        role: 'user' as const,
+        content: `以下是 Prompt 優化所需的完整資訊：
 
 初始使用者需求：
 """
@@ -88,46 +94,44 @@ ${sanitizedCurrent}
 上一輪審核者回饋（若有）：
 ${feedbackSection}
 
-請依據上述資訊，輸出一份完全優化後且可直接使用的提示詞內容。輸出時請不要包含任何額外說明，只需提供最終提示詞。`
-      const model = provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat'
-      const text = await callProvider(provider as ProviderName, model, [{ role: 'user', content: optimizationPrompt }], apiKey || '', { temperature: 0.3, maxTokens: 1024 })
-      return text
-    } catch (error) {
-      console.error('Optimization API error:', error)
-      // 失敗時返回模擬優化
-      return this.simulateOptimization(initialPrompt, currentPrompt, previousFeedback)
+請依據上述內容輸出一份可以直接使用的最終提示詞，不要輸出任何額外說明。`,
+      },
+    ]
+
+    const model = options?.model?.trim() || (provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat')
+    const temperature = typeof options?.temperature === 'number' ? options.temperature : 0.3
+    const maxTokens = typeof options?.maxTokens === 'number' ? options.maxTokens : 1024
+
+    const text = (await callProvider(
+      provider as ProviderName,
+      model,
+      messages,
+      apiKey || '',
+      { temperature, maxTokens }
+    ))?.trim()
+
+    if (!text) {
+      throw new Error('LLM 回傳內容為空，請檢查模型及金鑰設定')
     }
+
+    return text
   }
 
-  private simulateOptimization(initialPrompt: string, currentPrompt: string, previousFeedback: string[]) {
-    const base = (currentPrompt || initialPrompt).trim()
-    const feedbackNotes = previousFeedback.length
-      ? previousFeedback.map((item) => `- ${item}`).join('\n')
-      : '- 補充明確的角色設定\n- 加入具體步驟與條件\n- 說明需要的輸出格式'
-
-    return `# 角色
-你是一位專業助理，擅長將需求拆解為可執行的步驟並提供精準回覆。
-
-# 任務目標
-${base || '請根據使用者需求提供最佳解決方案'}
-
-# 執行流程
-1. 先確認使用者的核心需求與限制條件。
-2. 根據需求拆解出具體的步驟或章節，並補充必要的背景資訊。
-3. 主動提供安全與注意事項，如有需要可附上範例。
-
-# 審核回饋整合
-${feedbackNotes}
-
-# 輸出格式
-- 使用條列方式清楚呈現重點。
-- 若涉及步驟，請依序標號並提供細節。
-- 全程使用繁體中文回覆。`
-  }
-
-  async generateReviewScores(initialPrompt: string, prompt: string, provider: string, apiKey?: string): Promise<ReviewAnalysis> {
-    try {
-      const reviewPrompt = `${this.criticPrompt}
+  async generateReviewScores(
+    initialPrompt: string,
+    prompt: string,
+    provider: string,
+    apiKey: string | undefined,
+    options?: {
+      model?: string
+      maxTokens?: number
+    }
+  ): Promise<ReviewAnalysis> {
+    const messages = [
+      { role: 'system' as const, content: this.criticPrompt },
+      {
+        role: 'user' as const,
+        content: `請依據下列資訊提供評分結果，務必輸出合法 JSON：
 
 使用者初始需求：
 """
@@ -137,68 +141,59 @@ ${initialPrompt}
 待審核的提示詞：
 """
 ${prompt}
-"""
+"""`,
+      },
+    ]
 
-請只返回JSON格式的評分，不要添加任何其他內容。`
-      const model = provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat'
-      const jsonResponse = await callProvider(provider as ProviderName, model, [{ role: 'user', content: reviewPrompt }], apiKey || '', { temperature: 0 })
-      const text = (jsonResponse || '').trim()
+    const model = options?.model?.trim() || (provider === 'gemini' ? 'gemini-2.5-flash' : 'deepseek-chat')
+    const maxTokens = typeof options?.maxTokens === 'number' ? options.maxTokens : 512
 
-      // 嘗試解析JSON回應
-      try {
-        const parsed = JSON.parse(text) as {
-          scores?: Record<string, number>
-          overall_score?: number
-          actionable_suggestions?: unknown
-        }
+    const jsonResponse = await callProvider(
+      provider as ProviderName,
+      model,
+      messages,
+      apiKey || '',
+      { temperature: 0, maxTokens }
+    )
 
-        const normalizedScores = Object.entries(parsed.scores || {}).reduce<Record<string, number>>((acc, [key, value]) => {
-          if (typeof value === 'number' && !Number.isNaN(value)) {
-            acc[key] = value
-          }
-          return acc
-        }, {})
+    const text = (jsonResponse || '').trim()
+    if (!text) {
+      throw new Error('審核模型回傳內容為空，請檢查設定')
+    }
 
-        const feedback = Array.isArray(parsed.actionable_suggestions)
-          ? parsed.actionable_suggestions.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
-          : []
+    let parsed: {
+      scores?: Record<string, number>
+      overall_score?: number
+      actionable_suggestions?: unknown
+    }
 
-        const totalFromResponse = typeof parsed.overall_score === 'number' && !Number.isNaN(parsed.overall_score)
-          ? parsed.overall_score
-          : Object.values(normalizedScores).length
-            ? Object.values(normalizedScores).reduce((sum, num) => sum + num, 0) / Object.values(normalizedScores).length
-            : 0
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new Error('審核模型未回傳有效的 JSON，請調整提示詞或模型設定')
+    }
 
-        return {
-          scores: normalizedScores,
-          total: Math.round(totalFromResponse),
-          feedback: feedback.length ? feedback : ['加強角色與目標設定', '補充具體步驟與範例', '清楚定義輸出格式與限制'],
-        }
-      } catch {
-        // 如果解析失敗，返回模擬評分
-        return this.generateSimulatedScores()
+    const normalizedScores = Object.entries(parsed.scores || {}).reduce<Record<string, number>>((acc, [key, value]) => {
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        acc[key] = value
       }
-    } catch (error) {
-      console.error('Review API error:', error)
-      return this.generateSimulatedScores()
-    }
-  }
+      return acc
+    }, {})
 
-  private generateSimulatedScores(): ReviewAnalysis {
-    const scores = {
-      clarity: Math.floor(Math.random() * 15) + 85,
-      specificity: Math.floor(Math.random() * 15) + 85,
-      completeness: Math.floor(Math.random() * 15) + 85,
-      robustness: Math.floor(Math.random() * 15) + 85,
-      intent_adherence: Math.floor(Math.random() * 15) + 85,
-    }
+    const feedback = Array.isArray(parsed.actionable_suggestions)
+      ? parsed.actionable_suggestions.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      : []
 
-    const total = Math.round(Object.values(scores).reduce((sum, score) => sum + score, 0) / Object.values(scores).length)
+    const totalFromResponse = typeof parsed.overall_score === 'number' && !Number.isNaN(parsed.overall_score)
+      ? parsed.overall_score
+      : Object.values(normalizedScores).length
+        ? Object.values(normalizedScores).reduce((sum, num) => sum + num, 0) / Object.values(normalizedScores).length
+        : 0
 
     return {
-      scores,
-      total,
-      feedback: ['明確定義角色職責', '加入具體步驟與情境資訊', '說明輸出格式與品質標準'],
+      scores: normalizedScores,
+      total: Math.round(totalFromResponse),
+      feedback,
     }
   }
 }
@@ -206,19 +201,30 @@ ${prompt}
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { 
-      initialPrompt, 
-      iterations = 8, 
-      threshold = 90, 
+    const {
+      initialPrompt,
+      iterations = 8,
+      threshold = 90,
       provider = 'gemini',
       apiKey,
-      systemPrompts
+      model,
+      temperature,
+      maxTokens,
     } = body
 
-    const optimizer = new OptimizerClient(
-      systemPrompts?.improver,
-      systemPrompts?.critic
-    )
+    const optimizer = new OptimizerClient()
+
+    if (typeof initialPrompt !== 'string' || !initialPrompt.trim()) {
+      return Response.json(
+        {
+          message: '請提供要優化的初始提示詞內容',
+          code: 'MISSING_INITIAL_PROMPT',
+        },
+        { status: 400 }
+      )
+    }
+
+    const normalizedInitialPrompt = initialPrompt.trim()
     
     // Resolve API key (request payload > saved per-user value)
     let effectiveKey = (apiKey || '').trim()
@@ -246,79 +252,108 @@ export async function POST(request: NextRequest) {
     }
 
     const encoder = new TextEncoder()
+    const chosenModel = typeof model === 'string' && model.trim()
+      ? model.trim()
+      : provider === 'gemini'
+        ? 'gemini-2.5-flash'
+        : 'deepseek-chat'
+
+    const effectiveTemperature = typeof temperature === 'number' ? temperature : 0.3
+    const effectiveMaxTokens = typeof maxTokens === 'number' ? maxTokens : 1024
+
     const stream = new ReadableStream({
       async start(controller) {
         let bestScore = 0
         let bestPrompt = ''
-        let currentPrompt = initialPrompt
+        let currentPrompt = normalizedInitialPrompt
         let previousFeedback: string[] = []
 
         for (let round = 1; round <= iterations; round++) {
-          // Use the optimizer to improve the prompt
-          const improvedPrompt = await optimizer.optimizePrompt(initialPrompt, currentPrompt, previousFeedback, provider, effectiveKey)
+          try {
+            const improvedPrompt = await optimizer.optimizePrompt(
+              normalizedInitialPrompt,
+              currentPrompt,
+              previousFeedback,
+              provider,
+              effectiveKey,
+              { model: chosenModel, temperature: effectiveTemperature, maxTokens: effectiveMaxTokens }
+            )
 
-          // Generate review scores
-          const review = await optimizer.generateReviewScores(initialPrompt, improvedPrompt, provider, effectiveKey)
+            const review = await optimizer.generateReviewScores(
+              normalizedInitialPrompt,
+              improvedPrompt,
+              provider,
+              effectiveKey,
+              { model: chosenModel, maxTokens: Math.min(effectiveMaxTokens, 800) }
+            )
 
-          const totalScore = review.total
+            const totalScore = review.total
+            const feedback = review.feedback.length
+              ? review.feedback
+              : ['強化提示詞的清晰度', '補充必要的限制條件', '提供具體輸出格式建議']
 
-          const feedback = review.feedback.length
-            ? review.feedback
-            : ['強化提示詞的清晰度', '補充必要的限制條件', '提供具體輸出格式建議']
+            if (totalScore > bestScore) {
+              bestScore = totalScore
+              bestPrompt = improvedPrompt
+            }
 
-          // Update best result
-          if (totalScore > bestScore) {
-            bestScore = totalScore
-            bestPrompt = improvedPrompt
-          }
+            previousFeedback = feedback
+            currentPrompt = improvedPrompt
 
-          previousFeedback = feedback
-          currentPrompt = improvedPrompt
-
-          // Send round data
-          const roundData = {
-            round,
-            improved: improvedPrompt,
-            review: {
-              scores: review.scores,
-              total: totalScore,
-              feedback,
-            },
-            bestSoFar: {
-              prompt: bestPrompt,
-              score: bestScore,
-            },
-          }
-
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify(roundData)}\n\n`)
-          )
-
-          // Check stopping conditions
-          if (totalScore >= threshold) {
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({
-                type: 'final',
+            const roundData = {
+              round,
+              improved: improvedPrompt,
+              review: {
+                scores: review.scores,
+                total: totalScore,
+                feedback,
+              },
+              bestSoFar: {
                 prompt: bestPrompt,
                 score: bestScore,
-                stopBy: 'threshold',
+              },
+            }
+
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(roundData)}\n\n`)
+            )
+
+            if (totalScore >= threshold) {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify({
+                  type: 'final',
+                  prompt: bestPrompt,
+                  score: bestScore,
+                  stopBy: 'threshold',
+                })}\n\n`)
+              )
+              break
+            }
+
+            if (round === iterations) {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify({
+                  type: 'final',
+                  prompt: bestPrompt,
+                  score: bestScore,
+                  stopBy: 'max_iterations',
+                })}\n\n`)
+              )
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 500))
+          } catch (error) {
+            const message = error instanceof Error ? error.message : '未知錯誤，請稍後再試'
+            console.error('Optimizer pipeline error:', error)
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({
+                type: 'error',
+                round,
+                message,
               })}\n\n`)
             )
             break
           }
-
-          if (round === iterations) {
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({
-                type: 'final',
-                prompt: bestPrompt,
-                score: bestScore,
-                stopBy: 'max_iterations',
-              })}\n\n`)
-            )
-          }
-
-          await new Promise(resolve => setTimeout(resolve, 500))
         }
 
         controller.close()

--- a/src/components/settings/SystemPromptSection.tsx
+++ b/src/components/settings/SystemPromptSection.tsx
@@ -10,42 +10,32 @@ interface SystemPromptSectionProps {
 }
 
 export function SystemPromptSection({ systemPrompts, setSystemPrompt }: SystemPromptSectionProps) {
-  const groups: { key: keyof Settings['systemPrompts']; title: string; accent: string }[] = [
-    { key: 'improver', title: 'Improver System Prompt', accent: 'border-blue-500/30' },
-    { key: 'critic', title: 'Critic System Prompt', accent: 'border-purple-500/30' },
-    { key: 'chat', title: 'Chat System Prompt', accent: 'border-green-500/30' },
-  ]
-
   return (
     <CollapsibleSection
       title="System Prompts"
       icon={<svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 4c-2.21 0-4 1.79-4 4v2h8v-2c0-2.21-1.79-4-4-4z" /></svg>}
       defaultExpanded
     >
-      <div className="space-y-4">
-        {groups.map(({ key, title, accent }) => (
-          <div key={key} className={`rounded-lg border-l-2 ${accent} bg-muted/30 p-4`}>
-            <div className="mb-2 flex items-center justify-between">
-              <label className="text-sm font-medium" htmlFor={`${key}-prompt`}>
-                {title}
-              </label>
-              <button
-                type="button"
-                onClick={() => setSystemPrompt(key, DEFAULT_SYSTEM_PROMPTS[key])}
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-              >
-                Restore Default
-              </button>
-            </div>
-            <textarea
-              id={`${key}-prompt`}
-              value={systemPrompts[key] || DEFAULT_SYSTEM_PROMPTS[key]}
-              onChange={(event) => setSystemPrompt(key, event.target.value)}
-              rows={key === 'chat' ? 6 : 10}
-              className="w-full rounded-lg border border-border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-          </div>
-        ))}
+      <div className="rounded-lg border-l-2 border-green-500/30 bg-muted/30 p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <label className="text-sm font-medium" htmlFor="chat-prompt">
+            Chat System Prompt
+          </label>
+          <button
+            type="button"
+            onClick={() => setSystemPrompt('chat', DEFAULT_SYSTEM_PROMPTS.chat)}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Restore Default
+          </button>
+        </div>
+        <textarea
+          id="chat-prompt"
+          value={systemPrompts.chat || DEFAULT_SYSTEM_PROMPTS.chat}
+          onChange={(event) => setSystemPrompt('chat', event.target.value)}
+          rows={6}
+          className="w-full rounded-lg border border-border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
       </div>
     </CollapsibleSection>
   )

--- a/src/components/settings/defaultPrompts.ts
+++ b/src/components/settings/defaultPrompts.ts
@@ -1,42 +1,4 @@
 export const DEFAULT_SYSTEM_PROMPTS = {
-  improver: `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
-
-你的工作流程是：
-1.  **分析輸入**: 仔細理解用戶的\`初始需求\`、\`當前 Prompt 版本\`以及\`審核者回饋\`。
-2.  **應用最佳實踐**: 在你的新 Prompt 中，靈活運用以下一種或多種高級技巧來增強效果：
-    - **角色扮演 (Role-Playing)**: 明確指定 AI 扮演的角色。
-    - **結構化格式 (Structured Format)**: 使用 Markdown（如 #, ##, ###）來組織結構，例如 \`Role\`, \`Task\`, \`Context\`, \`Constraints\`, \`Output Format\` 等。
-    - **思維鏈 (Chain of Thought, CoT)**: 引導 AI 一步步思考。
-    - **提供範例 (Few-shot Examples)**: 給出輸入和輸出的範例，讓 AI 更好地理解期望。
-    - **明確的約束 (Constraints)**: 設定清晰的規則和限制，避免 AI 偏離主題。
-3.  **整合回饋**: 針對\`審核者回饋\`中的每一條建議，思考如何將其融入到新的 Prompt 中。
-4.  **輸出**: 只輸出**完整且可直接使用**的新 Prompt 內容，不要包含任何額外的解釋或對話。`,
-  critic: `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
-
-你的評估必須基於以下五個維度，每個維度滿分 100：
-1.  **清晰度 (Clarity)**: Prompt 是否清晰易懂，沒有歧義？
-2.  **具體性 (Specificity)**: 是否包含了足夠的細節和上下文，讓 AI 能準確執行任務？
-3.  **完整性 (Completeness)**: 是否考慮了任務的各個方面和潛在的邊界情況？
-4.  **穩健性 (Robustness)**: Prompt 是否足夠靈活，能應對輕微變化的輸入，而不是過於僵化？
-5.  **原意符合度 (Intent Adherence)**: 是否完全符合用戶的\`初始需求\`，沒有添加不相關或偏離核心目標的內容？
-
-你的工作流程是：
-1.  **比較**: 將\`待審核的 Prompt\`與用戶的\`初始需求\`進行比較，確保核心目標一致。
-2.  **評分**: 根據上述五個維度，獨立打分。
-3.  **計算總分**: \`overall_score\` 是五個維度分數的加權平均值 (原意符合度權重最高，例如 40%，其餘各 15%)。
-4.  **提供回饋**:
-    - \`feedback_summary\`: 用一句話總結你的整體看法。
-    - \`actionable_suggestions\`: 提供 2-3 條具體的、可立即執行的修改建議，用於指導下一個版本的改進。
-
-你的輸出必須是**嚴格的 JSON 格式**，結構如下：
-{
-  "scores": { "clarity": int, "specificity": int, "completeness": int, "robustness": int, "intent_adherence": int },
-  "overall_score": int,
-  "feedback_summary": "string",
-  "actionable_suggestions": ["string1", "string2", ...]
-}
-
-不要輸出任何 JSON 以外的內容。`,
   chat: '請輸出繁體中文回覆',
 }
 

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -91,7 +91,6 @@ async function callGemini(model: string, messages: ChatMessage[], apiKey: string
     { category: 'HARM_CATEGORY_SEXUAL', threshold: 'BLOCK_NONE' },
     { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
     { category: 'HARM_CATEGORY_VIOLENCE', threshold: 'BLOCK_NONE' },
-    { category: 'HARM_CATEGORY_SELF_HARM', threshold: 'BLOCK_NONE' },
   ]
 
   if (typeof cfg.temperature === 'number' || typeof cfg.maxTokens === 'number') {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -14,6 +14,9 @@ interface SyncResult {
   conflictResolved?: boolean
 }
 
+type SystemPromptSettings = { chat: string }
+const DEFAULT_CHAT_SYSTEM_PROMPT = '請輸出繁體中文回覆'
+
 export interface Settings {
   apiKeys: {
     gemini: string
@@ -24,11 +27,7 @@ export interface Settings {
     defaultProvider: 'gemini' | 'deepseek'
     defaultModel: string
   }
-  systemPrompts: {
-    improver: string
-    critic: string
-    chat: string
-  }
+  systemPrompts: SystemPromptSettings
   features: {
     showTokenUsage: boolean
     enableGeminiCache: boolean
@@ -76,45 +75,7 @@ const defaultSettings: Settings = {
     defaultModel: 'gemini-2.5-flash',
   },
   systemPrompts: {
-    improver: `你是一位世界頂尖的 Prompt 工程專家，你的任務是將一個簡單的用戶需求，轉化為一個結構化、功能強大、細節豐富的 Prompt。
-
-你的工作流程是：
-1.  **分析輸入**: 仔細理解用戶的\`初始需求\`、\`當前 Prompt 版本\`以及\`審核者回饋\`。
-2.  **應用最佳實踐**: 在你的新 Prompt 中，靈活運用以下一種或多種高級技巧來增強效果：
-    - **角色扮演 (Role-Playing)**: 明確指定 AI 扮演的角色。
-    - **結構化格式 (Structured Format)**: 使用 Markdown（如 #, ##, ###）來組織結構，例如 \`Role\`, \`Task\`, \`Context\`, \`Constraints\`, \`Output Format\` 等。
-    - **思維鏈 (Chain of Thought, CoT)**: 引導 AI 一步步思考。
-    - **提供範例 (Few-shot Examples)**: 給出輸入和輸出的範例，讓 AI 更好地理解期望。
-    - **明確的約束 (Constraints)**: 設定清晰的規則和限制，避免 AI 偏離主題。
-3.  **整合回饋**: 針對\`審核者回饋\`中的每一條建議，思考如何將其融入到新的 Prompt 中。
-4.  **輸出**: 只輸出**完整且可直接使用**的新 Prompt 內容，不要包含任何額外的解釋或對話。`,
-    critic: `你是一位嚴謹、注重細節的 AI 系統分析師。你的任務是評估一個給定的 Prompt，並提供結構化的、可執行的回饋。
-
-你的評估必須基於以下五個維度，每個維度滿分 100：
-1.  **清晰度 (Clarity)**: Prompt 是否清晰易懂，沒有歧義？
-2.  **具體性 (Specificity)**: 是否包含了足夠的細節和上下文，讓 AI 能準確執行任務？
-3.  **完整性 (Completeness)**: 是否考慮了任務的各個方面和潛在的邊界情況？
-4.  **穩健性 (Robustness)**: Prompt 是否足夠靈活，能應對輕微變化的輸入，而不是過於僵化？
-5.  **原意符合度 (Intent Adherence)**: 是否完全符合用戶的\`初始需求\`，沒有添加不相關或偏離核心目標的內容？
-
-你的工作流程是：
-1.  **比較**: 將\`待審核的 Prompt\`與用戶的\`初始需求\`進行比較，確保核心目標一致。
-2.  **評分**: 根據上述五個維度，獨立打分。
-3.  **計算總分**: \`overall_score\` 是五個維度分數的加權平均值 (原意符合度權重最高，例如 40%，其餘各 15%)。
-4.  **提供回饋**:
-    - \`feedback_summary\`: 用一句話總結你的整體看法。
-    - \`actionable_suggestions\`: 提供 2-3 條具體的、可立即執行的修改建議，用於指導下一個版本的改進。
-
-你的輸出必須是**嚴格的 JSON 格式**，結構如下：
-{
-  "scores": { "clarity": int, "specificity": int, "completeness": int, "robustness": int, "intent_adherence": int },
-  "overall_score": int,
-  "feedback_summary": "string",
-  "actionable_suggestions": ["string1", "string2", ...]
-}
-
-不要輸出任何 JSON 以外的內容。`,
-    chat: '請輸出繁體中文回覆',
+    chat: DEFAULT_CHAT_SYSTEM_PROMPT,
   },
   features: {
     showTokenUsage: true,
@@ -129,6 +90,14 @@ const defaultSettings: Settings = {
     gemini: [], // Will be populated when models are first fetched
     deepseek: [], // Will be populated when models are first fetched
   },
+}
+
+const sanitizeSystemPrompts = (value: unknown): SystemPromptSettings => {
+  if (value && typeof (value as { chat?: unknown }).chat === 'string') {
+    const rawChat = String((value as { chat: unknown }).chat)
+    return { chat: rawChat.trim().length ? rawChat : DEFAULT_CHAT_SYSTEM_PROMPT }
+  }
+  return { chat: DEFAULT_CHAT_SYSTEM_PROMPT }
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -155,7 +124,7 @@ export const useSettingsStore = create<SettingsState>()(
 
       setSystemPrompt: (type, prompt) => {
         set((state) => ({
-          systemPrompts: { ...state.systemPrompts, [type]: prompt },
+          systemPrompts: sanitizeSystemPrompts({ ...state.systemPrompts, [type]: prompt }),
         }))
         scheduleSettingsSync()
       },
@@ -218,7 +187,10 @@ export const useSettingsStore = create<SettingsState>()(
       },
 
       resetToDefaults: () => {
-        set(defaultSettings)
+        set(() => ({
+          ...defaultSettings,
+          systemPrompts: sanitizeSystemPrompts(defaultSettings.systemPrompts),
+        }))
         scheduleSettingsSync()
       },
 
@@ -267,7 +239,7 @@ export const useSettingsStore = create<SettingsState>()(
           const settingsData = {
             apiKeys: currentState.apiKeys,
             modelSettings: currentState.modelSettings,
-            systemPrompts: currentState.systemPrompts,
+            systemPrompts: sanitizeSystemPrompts(currentState.systemPrompts),
             features: currentState.features,
             connectionStatus: currentState.connectionStatus,
             userModelPreferences: currentState.userModelPreferences,
@@ -340,6 +312,7 @@ export const useSettingsStore = create<SettingsState>()(
           if (result.settings) {
             set({
               ...result.settings,
+              systemPrompts: sanitizeSystemPrompts(result.settings.systemPrompts),
               syncStatus: 'success',
               lastSyncAt: serverLastSync,
               settingsVersion: serverVersion,
@@ -366,7 +339,7 @@ export const useSettingsStore = create<SettingsState>()(
       // 排除同步狀態不持久化，只保留設定資料
       partialize: (state) => ({
         modelSettings: state.modelSettings,
-        systemPrompts: state.systemPrompts,
+        systemPrompts: sanitizeSystemPrompts(state.systemPrompts),
         features: state.features,
         connectionStatus: state.connectionStatus,
         userModelPreferences: state.userModelPreferences,


### PR DESCRIPTION
## Summary
- inline the optimizer improver and critic prompts in the API route and reuse the trimmed initial prompt throughout each iteration
- update the Gemini provider call to send system instructions, relaxed safety settings, and clearer empty-response errors
- remove improver/critic overrides from settings so only the chat prompt is configurable and sanitize stored system prompts

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e609a3663c833285338844ad5c9c38