### PR TITLE
Fix Gemini safety settings for optimizer

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -62,12 +62,24 @@ async function callGemini(model: string, messages: ChatMessage[], apiKey: string
     parts: [{ text: m.content }],
   }))
 
-  const body: { contents: { role: 'user' | 'model'; parts: { text: string }[] }[]; generationConfig?: { temperature?: number; maxOutputTokens?: number } } = { contents }
+  const body: {
+    contents: { role: 'user' | 'model'; parts: { text: string }[] }[]
+    generationConfig?: { temperature?: number; maxOutputTokens?: number }
+    safetySettings?: { category: string; threshold: string }[]
+  } = { contents }
   if (typeof cfg.temperature === 'number' || typeof cfg.maxTokens === 'number') {
     body.generationConfig = {}
     if (typeof cfg.temperature === 'number') body.generationConfig.temperature = cfg.temperature
     if (typeof cfg.maxTokens === 'number') body.generationConfig.maxOutputTokens = cfg.maxTokens
   }
+
+  body.safetySettings = [
+    'HARM_CATEGORY_HARASSMENT',
+    'HARM_CATEGORY_HATE_SPEECH',
+    'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+    'HARM_CATEGORY_DANGEROUS_CONTENT',
+    'HARM_CATEGORY_CIVIC_INTEGRITY',
+  ].map(category => ({ category, threshold: 'BLOCK_NONE' }))
 
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`
   const res = await fetch(url, {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -96,9 +96,34 @@ async function callGemini(model: string, messages: ChatMessage[], apiKey: string
     throw new Error(msg)
   }
   const data = await res.json()
-  const text = data.candidates?.[0]?.content?.parts?.[0]?.text
-  if (!text) throw new Error('Gemini returned empty response')
-  return text
+  const textCandidate = Array.isArray(data.candidates)
+    ? data.candidates
+        .map((candidate: { content?: { parts?: { text?: string }[] }; finishReason?: string }) => {
+          const parts = candidate.content?.parts || []
+          return parts
+            .map(part => (typeof part?.text === 'string' ? part.text : ''))
+            .join('')
+            .trim()
+        })
+        .find(Boolean)
+    : undefined
+
+  if (textCandidate) return textCandidate
+
+  const blockReason = data.promptFeedback?.blockReason
+  const finishReason = data.candidates?.[0]?.finishReason
+  const safetyRatings =
+    data.promptFeedback?.safetyRatings || data.candidates?.[0]?.safetyRatings
+
+  const details: string[] = []
+  if (blockReason) details.push(`blockReason: ${blockReason}`)
+  if (finishReason) details.push(`finishReason: ${finishReason}`)
+  if (Array.isArray(safetyRatings) && safetyRatings.length) {
+    details.push(`safetyRatings: ${JSON.stringify(safetyRatings)}`)
+  }
+
+  const suffix = details.length ? ` (${details.join(', ')})` : ''
+  throw new Error(`Gemini returned empty response${suffix}`)
 }
 
 async function callDeepSeek(model: string, messages: ChatMessage[], apiKey: string, cfg: GenConfig) {


### PR DESCRIPTION
## Summary
- update the Gemini provider request body to explicitly set allowed safety settings
- prevent invalid safety category errors that broke the prompt optimizer pipeline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e632fe34388332870bc32b4009475a